### PR TITLE
feat(drivers): add LinstorSR driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SM_DRIVERS += udev
 SM_DRIVERS += ISO
 SM_DRIVERS += HBA
 SM_DRIVERS += RawHBA
+SM_DRIVERS += Linstor
 SM_DRIVERS += LVHD
 SM_DRIVERS += LVHDoISCSI
 SM_DRIVERS += LVHDoHBA
@@ -34,6 +35,9 @@ SM_LIBS += verifyVHDsOnSR
 SM_LIBS += scsiutil
 SM_LIBS += scsi_host_rescan
 SM_LIBS += vhdutil
+SM_LIBS += linstorjournaler
+SM_LIBS += linstorvhdutil
+SM_LIBS += linstorvolumemanager
 SM_LIBS += lvhdutil
 SM_LIBS += cifutils
 SM_LIBS += xs_errors
@@ -193,6 +197,7 @@ install: precheck
 	cd $(SM_STAGING)$(SM_DEST) && rm -f OCFSoHBASR
 	ln -sf $(SM_DEST)mpathutil.py $(SM_STAGING)/sbin/mpathutil
 	install -m 755 drivers/02-vhdcleanup $(SM_STAGING)$(MASTER_SCRIPT_DEST)
+	install -m 755 drivers/linstor-manager $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)
 	install -m 755 drivers/lvhd-thin $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)
 	install -m 755 drivers/on_slave.py $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)/on-slave
 	install -m 755 drivers/testing-hooks $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -1,0 +1,1941 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2020  Vates SAS - ronan.abhamon@vates.fr
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from constants import CBTLOG_TAG
+from linstorjournaler import LinstorJournaler
+from linstorvhdutil import LinstorVhdUtil
+from linstorvolumemanager \
+    import LinstorVolumeManager, LinstorVolumeManagerError
+from lock import Lock
+import blktap2
+import cleanup
+import errno
+import scsiutil
+import SR
+import SRCommand
+import time
+import traceback
+import util
+import VDI
+import vhdutil
+import xmlrpclib
+import xs_errors
+
+from srmetadata import \
+    NAME_LABEL_TAG, NAME_DESCRIPTION_TAG, IS_A_SNAPSHOT_TAG, SNAPSHOT_OF_TAG, \
+    TYPE_TAG, VDI_TYPE_TAG, READ_ONLY_TAG, SNAPSHOT_TIME_TAG, \
+    METADATA_OF_POOL_TAG
+
+HIDDEN_TAG = 'hidden'
+
+# ==============================================================================
+
+# TODO: Supports 'VDI_INTRODUCE', 'VDI_RESET_ON_BOOT/2', 'SR_TRIM',
+# 'VDI_CONFIG_CBT', 'SR_PROBE'
+
+CAPABILITIES = [
+    'ATOMIC_PAUSE',
+    'SR_UPDATE',
+    'VDI_CREATE',
+    'VDI_DELETE',
+    'VDI_UPDATE',
+    'VDI_ATTACH',
+    'VDI_DETACH',
+    'VDI_ACTIVATE',
+    'VDI_DEACTIVATE',
+    'VDI_CLONE',
+    'VDI_MIRROR',
+    'VDI_RESIZE',
+    'VDI_SNAPSHOT',
+    'VDI_GENERATE_CONFIG'
+]
+
+CONFIGURATION = [
+    ['group-name', 'LVM group name'],
+    ['hosts', 'host names to use'],
+    ['redundancy', 'replication count'],
+    ['provisioning', '"thin" or "thick" are accepted']
+]
+
+DRIVER_INFO = {
+    'name': 'LINSTOR resources on XCP-ng',
+    'description': 'SR plugin which uses Linstor to manage VDIs',
+    'vendor': 'Vates',
+    'copyright': '(C) 2020 Vates',
+    'driver_version': '1.0',
+    'required_api_version': '1.0',
+    'capabilities': CAPABILITIES,
+    'configuration': CONFIGURATION
+}
+
+DRIVER_CONFIG = {'ATTACH_FROM_CONFIG_WITH_TAPDISK': False}
+
+OPS_EXCLUSIVE = [
+    'sr_create', 'sr_delete', 'sr_attach', 'sr_detach', 'sr_scan',
+    'sr_update', 'vdi_create', 'vdi_delete', 'vdi_clone', 'vdi_snapshot'
+]
+
+# ==============================================================================
+# Misc helpers used by LinstorSR and linstor-thin plugin.
+# ==============================================================================
+
+
+def compute_volume_size(virtual_size, image_type):
+    if image_type == vhdutil.VDI_TYPE_VHD:
+        # All LINSTOR VDIs have the metadata area preallocated for
+        # the maximum possible virtual size (for fast online VDI.resize).
+        meta_overhead = vhdutil.calcOverheadEmpty(LinstorVDI.MAX_SIZE)
+        bitmap_overhead = vhdutil.calcOverheadBitmap(virtual_size)
+        virtual_size += meta_overhead + bitmap_overhead
+    elif image_type != vhdutil.VDI_TYPE_RAW:
+        raise Exception('Invalid image type: {}'.format(image_type))
+
+    return LinstorVolumeManager.round_up_volume_size(virtual_size)
+
+
+def try_lock(lock):
+    for i in range(20):
+        if lock.acquireNoblock():
+            return
+        time.sleep(1)
+    raise util.SRBusyException()
+
+
+def attach_thin(session, journaler, linstor, sr_uuid, vdi_uuid):
+    volume_metadata = linstor.get_volume_metadata(vdi_uuid)
+    image_type = volume_metadata.get(VDI_TYPE_TAG)
+    if image_type == vhdutil.VDI_TYPE_RAW:
+        return
+
+    lock = Lock(vhdutil.LOCK_TYPE_SR, sr_uuid)
+    try:
+        try_lock(lock)
+
+        device_path = linstor.get_device_path(vdi_uuid)
+
+        # If the virtual VHD size is lower than the LINSTOR volume size,
+        # there is nothing to do.
+        vhd_size = compute_volume_size(
+            LinstorVhdUtil(session, linstor).get_size_virt(vdi_uuid),
+            image_type
+        )
+
+        volume_info = linstor.get_volume_info(vdi_uuid)
+        volume_size = volume_info.virtual_size
+
+        if vhd_size > volume_size:
+            inflate(
+                journaler, linstor, vdi_uuid, device_path,
+                vhd_size, volume_size
+            )
+    finally:
+        lock.release()
+
+
+def detach_thin(session, linstor, sr_uuid, vdi_uuid):
+    volume_metadata = linstor.get_volume_metadata(vdi_uuid)
+    image_type = volume_metadata.get(VDI_TYPE_TAG)
+    if image_type == vhdutil.VDI_TYPE_RAW:
+        return
+
+    lock = Lock(vhdutil.LOCK_TYPE_SR, sr_uuid)
+    try:
+        try_lock(lock)
+
+        vdi_ref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
+        vbds = session.xenapi.VBD.get_all_records_where(
+            'field "VDI" = "{}"'.format(vdi_ref)
+        )
+
+        num_plugged = 0
+        for vbd_rec in vbds.values():
+            if vbd_rec['currently_attached']:
+                num_plugged += 1
+                if num_plugged > 1:
+                    raise xs_errors.XenError(
+                        'VDIUnavailable',
+                        opterr='Cannot deflate VDI {}, already used by '
+                        'at least 2 VBDs'.format(vdi_uuid)
+                    )
+
+        device_path = linstor.get_device_path(vdi_uuid)
+        new_volume_size = LinstorVolumeManager.round_up_volume_size(
+            LinstorVhdUtil(session, linstor).get_size_phys(device_path)
+        )
+
+        volume_info = linstor.get_volume_info(vdi_uuid)
+        old_volume_size = volume_info.virtual_size
+        deflate(vdi_uuid, device_path, new_volume_size, old_volume_size)
+    finally:
+        lock.release()
+
+
+def inflate(journaler, linstor, vdi_uuid, vdi_path, new_size, old_size):
+    # Only inflate if the LINSTOR volume capacity is not enough.
+    new_size = LinstorVolumeManager.round_up_volume_size(new_size)
+    if new_size <= old_size:
+        return
+
+    util.SMlog(
+        'Inflate {} (new VHD size={}, previous={})'
+        .format(vdi_uuid, new_size, old_size)
+    )
+
+    journaler.create(
+        LinstorJournaler.INFLATE, vdi_uuid, old_size
+    )
+    linstor.resize_volume(vdi_uuid, new_size)
+
+    if not util.zeroOut(
+        vdi_path, new_size - vhdutil.VHD_FOOTER_SIZE,
+        vhdutil.VHD_FOOTER_SIZE
+    ):
+        raise xs_errors.XenError(
+            'EIO',
+            opterr='Failed to zero out VHD footer {}'.format(vdi_path)
+        )
+
+    vhdutil.setSizePhys(vdi_path, new_size, False)
+    journaler.remove(LinstorJournaler.INFLATE, vdi_uuid)
+
+
+def deflate(vdi_uuid, vdi_path, new_size, old_size):
+    new_size = LinstorVolumeManager.round_up_volume_size(new_size)
+    if new_size >= old_size:
+        return
+
+    util.SMlog(
+        'Deflate {} (new size={}, previous={})'
+        .format(vdi_uuid, new_size, old_size)
+    )
+
+    vhdutil.setSizePhys(vdi_path, new_size)
+    # TODO: Change the LINSTOR volume size using linstor.resize_volume.
+
+
+# ==============================================================================
+
+# Usage example:
+# xe sr-create type=linstor name-label=linstor-sr
+# host-uuid=d2deba7a-c5ad-4de1-9a20-5c8df3343e93
+# device-config:hosts=node-linstor1,node-linstor2,node-linstor3
+# device-config:group-name=vg_loop device-config:redundancy=2
+
+
+class LinstorSR(SR.SR):
+    DRIVER_TYPE = 'linstor'
+
+    PROVISIONING_TYPES = ['thin', 'thick']
+    PROVISIONING_DEFAULT = 'thin'
+
+    MANAGER_PLUGIN = 'linstor-manager'
+
+    # --------------------------------------------------------------------------
+    # SR methods.
+    # --------------------------------------------------------------------------
+
+    @staticmethod
+    def handles(type):
+        return type == LinstorSR.DRIVER_TYPE
+
+    def load(self, sr_uuid):
+        # Check parameters.
+        if 'hosts' not in self.dconf or not self.dconf['hosts']:
+            raise xs_errors.XenError('LinstorConfigHostsMissing')
+        if 'group-name' not in self.dconf or not self.dconf['group-name']:
+            raise xs_errors.XenError('LinstorConfigGroupNameMissing')
+        if 'redundancy' not in self.dconf or not self.dconf['redundancy']:
+            raise xs_errors.XenError('LinstorConfigRedundancyMissing')
+
+        self.driver_config = DRIVER_CONFIG
+
+        # Check provisioning config.
+        provisioning = self.dconf.get('provisioning')
+        if provisioning:
+            if provisioning in self.PROVISIONING_TYPES:
+                self._provisioning = provisioning
+            else:
+                raise xs_errors.XenError(
+                    'InvalidArg',
+                    opterr='Provisioning parameter must be one of {}'.format(
+                        self.PROVISIONING_TYPES
+                    )
+                )
+        else:
+            self._provisioning = self.PROVISIONING_DEFAULT
+
+        # Note: We don't have access to the session field if the
+        # 'vdi_attach_from_config' command is executed.
+        has_session = self.sr_ref and self.session is not None
+        if has_session:
+            self.sm_config = self.session.xenapi.SR.get_sm_config(self.sr_ref)
+        else:
+            self.sm_config = self.srcmd.params.get('sr_sm_config') or {}
+
+        provisioning = self.sm_config.get('provisioning')
+        if provisioning in self.PROVISIONING_TYPES:
+            self._provisioning = provisioning
+
+        # Define properties for SR parent class.
+        self.ops_exclusive = OPS_EXCLUSIVE
+        self.path = LinstorVolumeManager.DEV_ROOT_PATH
+        self.lock = Lock(vhdutil.LOCK_TYPE_SR, self.uuid)
+        self.sr_vditype = SR.DEFAULT_TAP
+
+        self._hosts = self.dconf['hosts'].split(',')
+        self._redundancy = int(self.dconf['redundancy'] or 1)
+        self._linstor = None  # Ensure that LINSTOR attribute exists.
+
+        self._is_master = False
+        if 'SRmaster' in self.dconf and self.dconf['SRmaster'] == 'true':
+            self._is_master = True
+        self._group_name = self.dconf['group-name']
+
+        if not has_session:
+            return
+
+        self._master_uri = 'linstor://{}'.format(
+            util.get_master_rec(self.session)['address']
+        )
+
+        self._journaler = LinstorJournaler(
+            self._master_uri, self._group_name, logger=util.SMlog
+        )
+
+        # Ensure ports are opened and LINSTOR controller/satellite
+        # are activated.
+        if self.srcmd.cmd == 'sr_create':
+            # TODO: Disable if necessary
+            self._enable_linstor_on_all_hosts(status=True)
+
+        try:
+            # Try to open SR if exists.
+            self._linstor = LinstorVolumeManager(
+                self._master_uri,
+                self._group_name,
+                repair=self._is_master,
+                logger=util.SMlog
+            )
+            self._vhdutil = LinstorVhdUtil(self.session, self._linstor)
+        except Exception as e:
+            if self.srcmd.cmd == 'sr_create':
+                pass  # Ignore exception in this specific case.
+            else:
+                raise xs_errors.XenError('SRUnavailable', opterr=str(e))
+
+        if self._linstor:
+            try:
+                hosts = self._linstor.disconnected_hosts
+            except Exception as e:
+                raise xs_errors.XenError('SRUnavailable', opterr=str(e))
+
+            if hosts:
+                raise xs_errors.XenError(
+                    'LinstorDisconnectedHost', opterr=str(hosts)
+                )
+
+            try:
+                # If the command is a SR command on the master, we must load
+                # all VDIs and clean journal transactions.
+                # We must load the VDIs in the snapshot case too.
+                if self._is_master and self.cmd not in [
+                    'vdi_attach', 'vdi_detach',
+                    'vdi_activate', 'vdi_deactivate'
+                ]:
+                    self._load_vdis()
+                    self._undo_all_journal_transactions()
+                    self._linstor.remove_resourceless_volumes()
+
+                self._synchronize_metadata()
+            except Exception as e:
+                util.SMlog(
+                    'Ignoring exception in LinstorSR.load: {}'.format(e)
+                )
+                util.SMlog(traceback.format_exc())
+
+    def create(self, uuid, size):
+        # `size` param is not used. ;)
+
+        util.SMlog('LinstorSR.create for {}'.format(self.uuid))
+        if not self._is_master:
+            util.SMlog('sr_create blocked for non-master')
+            raise xs_errors.XenError('LinstorMaster')
+
+        if self._redundancy > len(self._hosts):
+            raise xs_errors.XenError(
+                'LinstorSRCreate',
+                opterr='Redundancy greater than host count'
+            )
+
+        # Create SR.
+        # Throw if the SR already exists.
+        try:
+            self._linstor = LinstorVolumeManager.create_sr(
+                self._master_uri,
+                self._group_name,
+                self._hosts,
+                self._redundancy,
+                thin_provisioning=self._provisioning == 'thin',
+                logger=util.SMlog
+            )
+            self._vhdutil = LinstorVhdUtil(self.session, self._linstor)
+        except Exception as e:
+            util.SMlog('Failed to create LINSTOR SR: {}'.format(e))
+            raise xs_errors.XenError('LinstorSRCreate', opterr=str(e))
+
+    def delete(self, uuid):
+        util.SMlog('LinstorSR.delete for {}'.format(self.uuid))
+        if not self._is_master:
+            util.SMlog('sr_delete blocked for non-master')
+            raise xs_errors.XenError('LinstorMaster')
+
+        cleanup.gc_force(self.session, self.uuid)
+
+        if self.vdis:
+            raise xs_errors.XenError('SRNotEmpty')
+
+        try:
+            # TODO: Use specific exceptions. If the LINSTOR group doesn't
+            # exist, we can remove it without problem.
+
+            # TODO: Maybe remove all volumes unused by the SMAPI.
+            # We must ensure it's a safe idea...
+
+            self._linstor.destroy()
+            Lock.cleanupAll(self.uuid)
+        except Exception as e:
+            util.SMlog('Failed to delete LINSTOR SR: {}'.format(e))
+            raise xs_errors.XenError(
+                'LinstorSRDelete',
+                opterr=str(e)
+            )
+
+    def update(self, uuid):
+        # Well, how can we update a SR if it doesn't exist? :thinking:
+        if not self._linstor:
+            raise xs_errors.XenError(
+                'SRUnavailable',
+                opterr='no such volume group: {}'.format(self._group_name)
+            )
+
+        self._update_stats(0)
+
+        # Update the SR name and description only in LINSTOR metadata.
+        xenapi = self.session.xenapi
+        self._linstor.metadata = {
+            NAME_LABEL_TAG: util.to_plain_string(
+                xenapi.SR.get_name_label(self.sr_ref)
+            ),
+            NAME_DESCRIPTION_TAG: util.to_plain_string(
+                xenapi.SR.get_name_description(self.sr_ref)
+            )
+        }
+
+    def attach(self, uuid):
+        util.SMlog('LinstorSR.attach for {}'.format(self.uuid))
+
+        if not self._linstor:
+            raise xs_errors.XenError(
+                'SRUnavailable',
+                opterr='no such group: {}'.format(self._group_name)
+            )
+
+    def detach(self, uuid):
+        util.SMlog('LinstorSR.detach for {}'.format(self.uuid))
+        cleanup.abort(self.uuid)
+
+    def probe(self):
+        pass  # TODO
+
+    def scan(self, uuid):
+        util.SMlog('LinstorSR.scan for {}'.format(self.uuid))
+        if not self._is_master:
+            util.SMlog('sr_scan blocked for non-master')
+            raise xs_errors.XenError('LinstorMaster')
+
+        if not self._linstor:
+            raise xs_errors.XenError(
+                'SRUnavailable',
+                opterr='no such volume group: {}'.format(self._group_name)
+            )
+
+        self._update_physical_size()
+
+        for vdi_uuid in self.vdis.keys():
+            if self.vdis[vdi_uuid].deleted:
+                del self.vdis[vdi_uuid]
+
+        # Update the database before the restart of the GC to avoid
+        # bad sync in the process if new VDIs have been introduced.
+        ret = super(LinstorSR, self).scan(self.uuid)
+        self._kick_gc()
+        return ret
+
+    def vdi(self, uuid):
+        return LinstorVDI(self, uuid)
+
+    # --------------------------------------------------------------------------
+    # Network.
+    # --------------------------------------------------------------------------
+
+    def _enable_linstor(self, host, status):
+        ret = self.session.xenapi.host.call_plugin(
+            host, self.MANAGER_PLUGIN, 'enable', {'enabled': str(bool(status))}
+        )
+        util.SMlog('call-plugin returned: {}'.format(ret))
+        if ret == 'False':
+            raise xs_errors.XenError(
+                'SRUnavailable',
+                opterr='Plugin {} failed'.format(self.MANAGER_PLUGIN)
+            )
+
+    def _enable_linstor_on_master(self, status):
+        pools = self.session.xenapi.pool.get_all()
+        master = self.session.xenapi.pool.get_master(pools[0])
+        self._enable_linstor(master, status)
+
+    def _enable_linstor_on_all_hosts(self, status):
+        self._enable_linstor_on_master(status)
+        for slave in util.get_all_slaves(self.session):
+            self._enable_linstor(slave, status)
+
+    # --------------------------------------------------------------------------
+    # Metadata.
+    # --------------------------------------------------------------------------
+
+    def _synchronize_metadata_and_xapi(self):
+        try:
+            # First synch SR parameters.
+            self.update(self.uuid)
+
+            # Now update the VDI information in the metadata if required.
+            xenapi = self.session.xenapi
+            volumes_metadata = self._linstor.volumes_with_metadata
+            for vdi_uuid, volume_metadata in volumes_metadata.items():
+                try:
+                    vdi_ref = xenapi.VDI.get_by_uuid(vdi_uuid)
+                except Exception:
+                    # May be the VDI is not in XAPI yet dont bother.
+                    continue
+
+                label = util.to_plain_string(
+                    xenapi.VDI.get_name_label(vdi_ref)
+                )
+                description = util.to_plain_string(
+                    xenapi.VDI.get_name_description(vdi_ref)
+                )
+
+                if (
+                    volume_metadata.get(NAME_LABEL_TAG) != label or
+                    volume_metadata.get(NAME_DESCRIPTION_TAG) != description
+                ):
+                    self._linstor.update_volume_metadata(vdi_uuid, {
+                        NAME_LABEL_TAG: label,
+                        NAME_DESCRIPTION_TAG: description
+                    })
+        except Exception as e:
+            raise xs_errors.XenError(
+                'MetadataError',
+                opterr='Error synching SR Metadata and XAPI: {}'.format(e)
+            )
+
+    def _synchronize_metadata(self):
+        if not self._is_master:
+            return
+
+        util.SMlog('Synchronize metadata...')
+        if self.cmd == 'sr_attach':
+            try:
+                util.SMlog(
+                    'Synchronize SR metadata and the state on the storage.'
+                )
+                self._synchronize_metadata_and_xapi()
+            except Exception as e:
+                util.SMlog('Failed to synchronize metadata: {}'.format(e))
+
+    # --------------------------------------------------------------------------
+    # Stats.
+    # --------------------------------------------------------------------------
+
+    def _update_stats(self, virt_alloc_delta):
+        valloc = int(self.session.xenapi.SR.get_virtual_allocation(
+            self.sr_ref
+        ))
+
+        # Update size attributes of the SR parent class.
+        self.virtual_allocation = valloc + virt_alloc_delta
+
+        # Physical size contains the total physical size.
+        # i.e. the sum of the sizes of all devices on all hosts, not the AVG.
+        self._update_physical_size()
+
+        # Notify SR parent class.
+        self._db_update()
+
+    def _update_physical_size(self):
+        # Physical size contains the total physical size.
+        # i.e. the sum of the sizes of all devices on all hosts, not the AVG.
+        self.physical_size = self._linstor.physical_size
+
+        # `self._linstor.physical_free_size` contains the total physical free
+        # memory. If Thin provisioning is used we can't use it, we must use
+        # LINSTOR volume size to gives a good idea of the required
+        # usable memory to the users.
+        self.physical_utilisation = self._linstor.total_allocated_volume_size
+
+        # If Thick provisioning is used, we can use this line instead:
+        # self.physical_utilisation = \
+        #     self.physical_size - self._linstor.physical_free_size
+
+    # --------------------------------------------------------------------------
+    # VDIs.
+    # --------------------------------------------------------------------------
+
+    def _load_vdis(self):
+        if self.vdis:
+            return
+
+        # 1. Get existing VDIs in XAPI.
+        xenapi = self.session.xenapi
+        xapi_vdi_uuids = set()
+        for vdi in xenapi.SR.get_VDIs(self.sr_ref):
+            xapi_vdi_uuids.add(xenapi.VDI.get_uuid(vdi))
+
+        # 2. Get volumes info.
+        all_volume_info = self._linstor.volumes_with_info
+        volumes_metadata = self._linstor.volumes_with_metadata
+
+        # 3. Get CBT vdis.
+        # See: https://support.citrix.com/article/CTX230619
+        cbt_vdis = set()
+        for volume_metadata in volumes_metadata.values():
+            cbt_uuid = volume_metadata.get(CBTLOG_TAG)
+            if cbt_uuid:
+                cbt_vdis.add(cbt_uuid)
+
+        introduce = False
+
+        if self.cmd == 'sr_scan':
+            has_clone_entries = list(self._journaler.get_all(
+                LinstorJournaler.CLONE
+            ).items())
+
+            if has_clone_entries:
+                util.SMlog(
+                    'Cannot introduce VDIs during scan because it exists '
+                    'CLONE entries in journaler on SR {}'.format(self.uuid)
+                )
+            else:
+                introduce = True
+
+        # 4. Now check all volume info.
+        vdi_to_snaps = {}
+        for vdi_uuid, volume_info in all_volume_info.items():
+            if vdi_uuid.startswith(cleanup.SR.TMP_RENAME_PREFIX):
+                continue
+
+            # 4.a. Check if the VDI in LINSTOR is in XAPI VDIs.
+            if vdi_uuid not in xapi_vdi_uuids:
+                if not introduce:
+                    continue
+
+                volume_metadata = volumes_metadata.get(vdi_uuid)
+                if not volume_metadata:
+                    util.SMlog(
+                        'Skipping volume {} because no metadata could be found'
+                        .format(vdi_uuid)
+                    )
+                    continue
+
+                util.SMlog(
+                    'Trying to introduce VDI {} as it is present in '
+                    'LINSTOR and not in XAPI...'
+                    .format(vdi_uuid)
+                )
+
+                try:
+                    self._linstor.get_device_path(vdi_uuid)
+                except Exception as e:
+                    util.SMlog(
+                        'Cannot introduce {}, unable to get path: {}'
+                        .format(vdi_uuid, e)
+                    )
+                    continue
+
+                name_label = volume_metadata.get(NAME_LABEL_TAG) or ''
+                type = volume_metadata.get(TYPE_TAG) or 'user'
+                vdi_type = volume_metadata.get(VDI_TYPE_TAG)
+
+                if not vdi_type:
+                    util.SMlog(
+                        'Cannot introduce {} '.format(vdi_uuid) +
+                        'without vdi_type'
+                    )
+                    continue
+
+                sm_config = {
+                    'vdi_type': vdi_type
+                }
+
+                if vdi_type == vhdutil.VDI_TYPE_RAW:
+                    managed = not volume_metadata.get(HIDDEN_TAG)
+                elif vdi_type == vhdutil.VDI_TYPE_VHD:
+                    vhd_info = self._vhdutil.get_vhd_info(vdi_uuid)
+                    managed = not vhd_info.hidden
+                    if vhd_info.parentUuid:
+                        sm_config['vhd-parent'] = vhd_info.parentUuid
+                else:
+                    util.SMlog(
+                        'Cannot introduce {} with invalid VDI type {}'
+                        .format(vdi_uuid, vdi_type)
+                    )
+                    continue
+
+                util.SMlog(
+                    'Introducing VDI {} '.format(vdi_uuid) +
+                    ' (name={}, virtual_size={}, physical_size={})'.format(
+                        name_label,
+                        volume_info.virtual_size,
+                        volume_info.physical_size
+                    )
+                )
+
+                vdi_ref = xenapi.VDI.db_introduce(
+                    vdi_uuid,
+                    name_label,
+                    volume_metadata.get(NAME_DESCRIPTION_TAG) or '',
+                    self.sr_ref,
+                    type,
+                    False,  # sharable
+                    bool(volume_metadata.get(READ_ONLY_TAG)),
+                    {},  # other_config
+                    vdi_uuid,  # location
+                    {},  # xenstore_data
+                    sm_config,
+                    managed,
+                    str(volume_info.virtual_size),
+                    str(volume_info.physical_size)
+                )
+
+                is_a_snapshot = volume_metadata.get(IS_A_SNAPSHOT_TAG)
+                xenapi.VDI.set_is_a_snapshot(vdi_ref, bool(is_a_snapshot))
+                if is_a_snapshot:
+                    xenapi.VDI.set_snapshot_time(
+                        vdi_ref,
+                        xmlrpclib.DateTime(
+                            volume_metadata[SNAPSHOT_TIME_TAG] or
+                            '19700101T00:00:00Z'
+                        )
+                    )
+
+                    snap_uuid = volume_metadata[SNAPSHOT_OF_TAG]
+                    if snap_uuid in vdi_to_snaps:
+                        vdi_to_snaps[snap_uuid].append(vdi_uuid)
+                    else:
+                        vdi_to_snaps[snap_uuid] = [vdi_uuid]
+
+            # 4.b. Add the VDI in the list.
+            vdi = self.vdi(vdi_uuid)
+            self.vdis[vdi_uuid] = vdi
+
+            if vdi.vdi_type == vhdutil.VDI_TYPE_VHD:
+                vdi.sm_config_override['key_hash'] = \
+                    self._vhdutil.get_key_hash(vdi_uuid)
+
+            # 4.c. Update CBT status of disks either just added
+            # or already in XAPI.
+            cbt_uuid = volume_metadata.get(CBTLOG_TAG)
+            if cbt_uuid in cbt_vdis:
+                vdi_ref = xenapi.VDI.get_by_uuid(vdi_uuid)
+                xenapi.VDI.set_cbt_enabled(vdi_ref, True)
+                # For existing VDIs, update local state too.
+                # Scan in base class SR updates existing VDIs
+                # again based on local states.
+                self.vdis[vdi_uuid].cbt_enabled = True
+                cbt_vdis.remove(cbt_uuid)
+
+        # 5. Now set the snapshot statuses correctly in XAPI.
+        for src_uuid in vdi_to_snaps:
+            try:
+                src_ref = xenapi.VDI.get_by_uuid(src_uuid)
+            except Exception:
+                # The source VDI no longer exists, continue.
+                continue
+
+            for snap_uuid in vdi_to_snaps[src_uuid]:
+                try:
+                    # This might fail in cases where its already set.
+                    snap_ref = xenapi.VDI.get_by_uuid(snap_uuid)
+                    xenapi.VDI.set_snapshot_of(snap_ref, src_ref)
+                except Exception as e:
+                    util.SMlog('Setting snapshot failed: {}'.format(e))
+
+        # TODO: Check correctly how to use CBT.
+        # Update cbt_enabled on the right VDI, check LVM/FileSR code.
+
+        # 6. If we have items remaining in this list,
+        # they are cbt_metadata VDI that XAPI doesn't know about.
+        # Add them to self.vdis and they'll get added to the DB.
+        for cbt_uuid in cbt_vdis:
+            new_vdi = self.vdi(cbt_uuid)
+            new_vdi.ty = 'cbt_metadata'
+            new_vdi.cbt_enabled = True
+            self.vdis[cbt_uuid] = new_vdi
+
+        # 7. Update virtual allocation, build geneology and remove useless VDIs
+        self.virtual_allocation = 0
+
+        # 8. Build geneology.
+        geneology = {}
+
+        for vdi_uuid, vdi in self.vdis.items():
+            if vdi.parent:
+                if vdi.parent in self.vdis:
+                    self.vdis[vdi.parent].read_only = True
+                if vdi.parent in geneology:
+                    geneology[vdi.parent].append(vdi_uuid)
+                else:
+                    geneology[vdi.parent] = [vdi_uuid]
+            if not vdi.hidden:
+                self.virtual_allocation += vdi.utilisation
+
+        # 9. Remove all hidden leaf nodes to avoid introducing records that
+        # will be GC'ed.
+        for vdi_uuid in self.vdis.keys():
+            if vdi_uuid not in geneology and self.vdis[vdi_uuid].hidden:
+                util.SMlog(
+                    'Scan found hidden leaf ({}), ignoring'.format(vdi_uuid)
+                )
+                del self.vdis[vdi_uuid]
+
+    # --------------------------------------------------------------------------
+    # Journals.
+    # --------------------------------------------------------------------------
+
+    def _get_vdi_path_and_parent(self, vdi_uuid, volume_name):
+        try:
+            device_path = self._linstor.build_device_path(volume_name)
+            if not util.pathexists(device_path):
+                return (None, None)
+
+            # If it's a RAW VDI, there is no parent.
+            volume_metadata = self._linstor.get_volume_metadata(vdi_uuid)
+            vdi_type = volume_metadata[VDI_TYPE_TAG]
+            if vdi_type == vhdutil.VDI_TYPE_RAW:
+                return (device_path, None)
+
+            # Otherwise it's a VHD and a parent can exist.
+            if not self._vhdutil.check(vdi_uuid):
+                return (None, None)
+
+            vhd_info = self._vhdutil.get_vhd_info(vdi_uuid)
+            if vhd_info:
+                return (device_path, vhd_info.parentUuid)
+        except Exception as e:
+            util.SMlog(
+                'Failed to get VDI path and parent, ignoring: {}'
+                .format(e)
+            )
+        return (None, None)
+
+    def _undo_all_journal_transactions(self):
+        util.SMlog('Undoing all journal transactions...')
+        self.lock.acquire()
+        try:
+            self._handle_interrupted_inflate_ops()
+            self._handle_interrupted_clone_ops()
+            pass
+        finally:
+            self.lock.release()
+
+    def _handle_interrupted_inflate_ops(self):
+        transactions = self._journaler.get_all(LinstorJournaler.INFLATE)
+        for vdi_uuid, old_size in transactions.items():
+            self._handle_interrupted_inflate(vdi_uuid, old_size)
+            self._journaler.remove(LinstorJournaler.INFLATE, vdi_uuid)
+
+    def _handle_interrupted_clone_ops(self):
+        transactions = self._journaler.get_all(LinstorJournaler.CLONE)
+        for vdi_uuid, old_size in transactions.items():
+            self._handle_interrupted_clone(vdi_uuid, old_size)
+            self._journaler.remove(LinstorJournaler.CLONE, vdi_uuid)
+
+    def _handle_interrupted_inflate(self, vdi_uuid, old_size):
+        util.SMlog(
+            '*** INTERRUPTED INFLATE OP: for {} ({})'
+            .format(vdi_uuid, old_size)
+        )
+
+        vdi = self.vdis.get(vdi_uuid)
+        if not vdi:
+            util.SMlog('Cannot deflate missing VDI {}'.format(vdi_uuid))
+            return
+
+        current_size = self._linstor.get_volume_info(self.uuid).virtual_size
+        util.zeroOut(
+            vdi.path,
+            current_size - vhdutil.VHD_FOOTER_SIZE,
+            vhdutil.VHD_FOOTER_SIZE
+        )
+        deflate(vdi_uuid, vdi.path, old_size, current_size)
+
+    def _handle_interrupted_clone(
+        self, vdi_uuid, clone_info, force_undo=False
+    ):
+        util.SMlog(
+            '*** INTERRUPTED CLONE OP: for {} ({})'
+            .format(vdi_uuid, clone_info)
+        )
+
+        base_uuid, snap_uuid = clone_info.split(':')
+
+        # Use LINSTOR data because new VDIs may not be in the XAPI.
+        volume_names = self._linstor.volumes_with_name
+
+        # Check if we don't have a base VDI. (If clone failed at startup.)
+        if base_uuid not in volume_names:
+            if vdi_uuid in volume_names:
+                util.SMlog('*** INTERRUPTED CLONE OP: nothing to do')
+                return
+            raise util.SMException(
+                'Base copy {} not present, but no original {} found'
+                .format(base_uuid, vdi_uuid)
+            )
+
+        if force_undo:
+            util.SMlog('Explicit revert')
+            self._undo_clone(
+                 volume_names, vdi_uuid, base_uuid, snap_uuid
+            )
+            return
+
+        # If VDI or snap uuid is missing...
+        if vdi_uuid not in volume_names or \
+                (snap_uuid and snap_uuid not in volume_names):
+            util.SMlog('One or both leaves missing => revert')
+            self._undo_clone(volume_names, vdi_uuid, base_uuid, snap_uuid)
+            return
+
+        vdi_path, vdi_parent_uuid = self._get_vdi_path_and_parent(
+            vdi_uuid, volume_names[vdi_uuid]
+        )
+        snap_path, snap_parent_uuid = self._get_vdi_path_and_parent(
+            snap_uuid, volume_names[snap_uuid]
+        )
+
+        if not vdi_path or (snap_uuid and not snap_path):
+            util.SMlog('One or both leaves invalid (and path(s)) => revert')
+            self._undo_clone(volume_names, vdi_uuid, base_uuid, snap_uuid)
+            return
+
+        util.SMlog('Leaves valid but => revert')
+        self._undo_clone(volume_names, vdi_uuid, base_uuid, snap_uuid)
+
+    def _undo_clone(self, volume_names, vdi_uuid, base_uuid, snap_uuid):
+        base_path = self._linstor.build_device_path(volume_names[base_uuid])
+        base_metadata = self._linstor.get_volume_metadata(base_uuid)
+        base_type = base_metadata[VDI_TYPE_TAG]
+
+        if not util.pathexists(base_path):
+            util.SMlog('Base not found! Exit...')
+            util.SMlog('*** INTERRUPTED CLONE OP: rollback fail')
+            return
+
+        # Un-hide the parent.
+        self._linstor.update_volume_metadata(base_uuid, {READ_ONLY_TAG: False})
+        if base_type == vhdutil.VDI_TYPE_VHD:
+            vhd_info = self._vhdutil.get_vhd_info(base_uuid, False)
+            if vhd_info.hidden:
+                vhdutil.setHidden(base_path, False)
+        elif base_type == vhdutil.VDI_TYPE_RAW and \
+                base_metadata.get(HIDDEN_TAG):
+            self._linstor.update_volume_metadata(
+                base_uuid, {HIDDEN_TAG: False}
+            )
+
+        # Remove the child nodes.
+        if snap_uuid and snap_uuid in volume_names:
+            snap_metadata = self._linstor.get_volume_metadata(snap_uuid)
+
+            if snap_metadata.get(VDI_TYPE_TAG) != vhdutil.VDI_TYPE_VHD:
+                raise util.SMException('Clone {} not VHD'.format(snap_uuid))
+            self._linstor.destroy_volume(snap_uuid)
+
+        if vdi_uuid in volume_names:
+            self._linstor.destroy_volume(vdi_uuid)
+
+        # Rename!
+        self._linstor.update_volume_uuid(base_uuid, vdi_uuid)
+
+        # Inflate to the right size.
+        if base_type == vhdutil.VDI_TYPE_VHD:
+            vdi = self.vdi(vdi_uuid)
+            volume_size = compute_volume_size(vdi.size, vdi.vdi_type)
+            inflate(
+                self._journaler, self._linstor, vdi_uuid, vdi.path,
+                volume_size, vdi.capacity
+            )
+            self.vdis[vdi_uuid] = vdi
+
+        # At this stage, tapdisk and SM vdi will be in paused state. Remove
+        # flag to facilitate vm deactivate.
+        vdi_ref = self.session.xenapi.VDI.get_by_uuid(vdi_uuid)
+        self.session.xenapi.VDI.remove_from_sm_config(vdi_ref, 'paused')
+
+        util.SMlog('*** INTERRUPTED CLONE OP: rollback success')
+
+    # --------------------------------------------------------------------------
+    # Misc.
+    # --------------------------------------------------------------------------
+
+    def _ensure_space_available(self, amount_needed):
+        space_available = self._linstor.max_volume_size_allowed
+        if (space_available < amount_needed):
+            util.SMlog(
+                'Not enough space! Free space: {}, need: {}'.format(
+                    space_available, amount_needed
+                )
+            )
+            raise xs_errors.XenError('SRNoSpace')
+
+    def _kick_gc(self):
+        # Don't bother if an instance already running. This is just an
+        # optimization to reduce the overhead of forking a new process if we
+        # don't have to, but the process will check the lock anyways.
+        lock = Lock(cleanup.LOCK_TYPE_RUNNING, self.uuid)
+        if not lock.acquireNoblock():
+            if not cleanup.should_preempt(self.session, self.uuid):
+                util.SMlog('A GC instance already running, not kicking')
+                return
+
+            util.SMlog('Aborting currently-running coalesce of garbage VDI')
+            try:
+                if not cleanup.abort(self.uuid, soft=True):
+                    util.SMlog('The GC has already been scheduled to re-start')
+            except util.CommandException as e:
+                if e.code != errno.ETIMEDOUT:
+                    raise
+                util.SMlog('Failed to abort the GC')
+        else:
+            lock.release()
+
+        util.SMlog('Kicking GC')
+        cleanup.gc(self.session, self.uuid, True)
+
+# ==============================================================================
+# LinstorSr VDI
+# ==============================================================================
+
+
+class LinstorVDI(VDI.VDI):
+    # Warning: Not the same values than vhdutil.VDI_TYPE_*.
+    # These values represents the types given on the command line.
+    TYPE_RAW = 'raw'
+    TYPE_VHD = 'vhd'
+
+    MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024  # Max VHD size.
+
+    # Metadata size given to the "S" param of vhd-util create.
+    # "-S size (MB) for metadata preallocation".
+    # Increase the performance when resize is called.
+    MAX_METADATA_VIRT_SIZE = 2 * 1024 * 1024
+
+    # --------------------------------------------------------------------------
+    # VDI methods.
+    # --------------------------------------------------------------------------
+
+    def load(self, vdi_uuid):
+        self._lock = self.sr.lock
+        self._exists = True
+        self._linstor = self.sr._linstor
+
+        # Update hidden parent property.
+        self.hidden = False
+
+        def raise_bad_load(e):
+            raise xs_errors.XenError(
+                'VDIUnavailable',
+                opterr='Could not load {} because: {}'.format(self.uuid, e)
+            )
+
+        #  Try to load VDI.
+        try:
+            if (
+                self.sr.srcmd.cmd == 'vdi_attach_from_config' or
+                self.sr.srcmd.cmd == 'vdi_detach_from_config'
+            ) and self.sr.srcmd.params['vdi_uuid'] == self.uuid:
+                self.vdi_type = vhdutil.VDI_TYPE_RAW
+                self.path = self.sr.srcmd.params['vdi_path']
+            else:
+                self._determine_type_and_path()
+                self._load_this()
+
+            util.SMlog('VDI {} loaded! (path={}, hidden={})'.format(
+                self.uuid, self.path, self.hidden
+            ))
+        except LinstorVolumeManagerError as e:
+            # 1. It may be a VDI deletion.
+            if e.code == LinstorVolumeManagerError.ERR_VOLUME_NOT_EXISTS:
+                if self.sr.srcmd.cmd == 'vdi_delete':
+                    self.deleted = True
+                    return
+
+            # 2. Or maybe a creation.
+            if self.sr.srcmd.cmd == 'vdi_create':
+                # Set type attribute of VDI parent class.
+                # We use VHD by default.
+                self.vdi_type = vhdutil.VDI_TYPE_VHD
+                self._key_hash = None  # Only used in create.
+
+                self._exists = False
+                vdi_sm_config = self.sr.srcmd.params.get('vdi_sm_config')
+                if vdi_sm_config is not None:
+                    type = vdi_sm_config.get('type')
+                    if type is not None:
+                        if type == self.TYPE_RAW:
+                            self.vdi_type = vhdutil.VDI_TYPE_RAW
+                        elif type == self.TYPE_VHD:
+                            self.vdi_type = vhdutil.VDI_TYPE_VHD
+                        else:
+                            raise xs_errors.XenError(
+                                'VDICreate',
+                                opterr='Invalid VDI type {}'.format(type)
+                            )
+                    if self.vdi_type == vhdutil.VDI_TYPE_VHD:
+                        self._key_hash = vdi_sm_config.get('key_hash')
+
+                # For the moment we don't have a path.
+                self._update_device_name(None)
+                return
+            raise_bad_load(e)
+        except Exception as e:
+            raise_bad_load(e)
+
+    def create(self, sr_uuid, vdi_uuid, size):
+        # Usage example:
+        # xe vdi-create sr-uuid=39a5826b-5a90-73eb-dd09-51e3a116f937
+        # name-label="linstor-vdi-1" virtual-size=4096MiB sm-config:type=vhd
+
+        # 1. Check if we are on the master and if the VDI doesn't exist.
+        util.SMlog('LinstorVDI.create for {}'.format(self.uuid))
+        if not self.sr._is_master:
+            raise xs_errors.XenError('LinstorMaster')
+        if self._exists:
+            raise xs_errors.XenError('VDIExists')
+
+        assert self.uuid
+        assert self.ty
+        assert self.vdi_type
+
+        # 2. Compute size and check space available.
+        size = vhdutil.validate_and_round_vhd_size(long(size))
+        util.SMlog('LinstorVDI.create: type={}, size={}'.format(
+            self.vdi_type, size
+        ))
+
+        volume_size = compute_volume_size(size, self.vdi_type)
+        self.sr._ensure_space_available(volume_size)
+
+        # 3. Set sm_config attribute of VDI parent class.
+        self.sm_config = self.sr.srcmd.params['vdi_sm_config']
+
+        # 4. Create!
+        failed = False
+        try:
+            self._linstor.create_volume(
+                self.uuid, volume_size, persistent=False
+            )
+            volume_info = self._linstor.get_volume_info(self.uuid)
+
+            self._update_device_name(volume_info.name)
+
+            if self.vdi_type == vhdutil.VDI_TYPE_RAW:
+                self.size = volume_info.virtual_size
+            else:
+                vhdutil.create(
+                    self.path, size, False, self.MAX_METADATA_VIRT_SIZE
+                )
+                self.size = self.sr._vhdutil.get_size_virt(self.uuid)
+
+            if self._key_hash:
+                vhdutil.setKey(self.path, self._key_hash)
+
+            # Because vhdutil commands modify the volume data,
+            # we must retrieve a new time the utilisation size.
+            volume_info = self._linstor.get_volume_info(self.uuid)
+
+            volume_metadata = {
+                NAME_LABEL_TAG: util.to_plain_string(self.label),
+                NAME_DESCRIPTION_TAG: util.to_plain_string(self.description),
+                IS_A_SNAPSHOT_TAG: False,
+                SNAPSHOT_OF_TAG: '',
+                SNAPSHOT_TIME_TAG: '',
+                TYPE_TAG: self.ty,
+                VDI_TYPE_TAG: self.vdi_type,
+                READ_ONLY_TAG: bool(self.read_only),
+                METADATA_OF_POOL_TAG: ''
+            }
+            self._linstor.set_volume_metadata(self.uuid, volume_metadata)
+            self._linstor.mark_volume_as_persistent(self.uuid)
+        except util.CommandException as e:
+            failed = True
+            raise xs_errors.XenError(
+                'VDICreate', opterr='error {}'.format(e.code)
+            )
+        except Exception as e:
+            failed = True
+            raise xs_errors.XenError('VDICreate', opterr='error {}'.format(e))
+        finally:
+            if failed:
+                util.SMlog('Unable to create VDI {}'.format(self.uuid))
+                try:
+                    self._linstor.destroy_volume(self.uuid)
+                except Exception as e:
+                    util.SMlog(
+                        'Ignoring exception after fail in LinstorVDI.create: '
+                        '{}'.format(e)
+                    )
+
+        self.utilisation = volume_info.physical_size
+        self.sm_config['vdi_type'] = self.vdi_type
+
+        self.ref = self._db_introduce()
+        self.sr._update_stats(volume_info.virtual_size)
+
+        return VDI.VDI.get_params(self)
+
+    def delete(self, sr_uuid, vdi_uuid, data_only=False):
+        util.SMlog('LinstorVDI.delete for {}'.format(self.uuid))
+
+        if self.attached:
+            raise xs_errors.XenError('VDIInUse')
+
+        if self.deleted:
+            return super(LinstorVDI, self).delete(
+                sr_uuid, vdi_uuid, data_only
+            )
+
+        vdi_ref = self.sr.srcmd.params['vdi_ref']
+        if not self.session.xenapi.VDI.get_managed(vdi_ref):
+            raise xs_errors.XenError(
+                'VDIDelete',
+                opterr='Deleting non-leaf node not permitted'
+            )
+
+        try:
+            # Remove from XAPI and delete from LINSTOR.
+            self._linstor.destroy_volume(self.uuid)
+            if not data_only:
+                self._db_forget()
+
+            self.sr.lock.cleanupAll(vdi_uuid)
+        except Exception as e:
+            util.SMlog(
+                'Failed to remove the volume (maybe is leaf coalescing) '
+                'for {} err:{}'.format(self.uuid, e)
+            )
+            raise xs_errors.XenError('VDIDelete', opterr=str(e))
+
+        if self.uuid in self.sr.vdis:
+            del self.sr.vdis[self.uuid]
+
+        # TODO: Check size after delete.
+        self.sr._update_stats(-self.capacity)
+        self.sr._kick_gc()
+        return super(LinstorVDI, self).delete(sr_uuid, vdi_uuid, data_only)
+
+    def attach(self, sr_uuid, vdi_uuid):
+        util.SMlog('LinstorVDI.attach for {}'.format(self.uuid))
+
+        if (
+            self.sr.srcmd.cmd != 'vdi_attach_from_config' or
+            self.sr.srcmd.params['vdi_uuid'] != self.uuid
+        ) and self.sr._journaler.has_entries(self.uuid):
+            raise xs_errors.XenError(
+                'VDIUnavailable',
+                opterr='Interrupted operation detected on this VDI, '
+                'scan SR first to trigger auto-repair'
+            )
+
+        writable = 'args' not in self.sr.srcmd.params or \
+            self.sr.srcmd.params['args'][0] == 'true'
+
+        # We need to inflate the volume if we don't have enough place
+        # to mount the VHD image. I.e. the volume capacity must be greater
+        # than the VHD size + bitmap size.
+        need_inflate = True
+        if self.vdi_type == vhdutil.VDI_TYPE_RAW or not writable or \
+                self.capacity >= compute_volume_size(self.size, self.vdi_type):
+            need_inflate = False
+
+        if need_inflate:
+            try:
+                self._prepare_thin(True)
+            except Exception as e:
+                raise xs_errors.XenError(
+                    'VDIUnavailable',
+                    opterr='Failed to attach VDI during "prepare thin": {}'
+                    .format(e)
+                )
+
+        if not util.pathexists(self.path):
+            raise xs_errors.XenError(
+                'VDIUnavailable', opterr='Could not find: {}'.format(self.path)
+            )
+
+        if not hasattr(self, 'xenstore_data'):
+            self.xenstore_data = {}
+
+        # TODO: Is it useful?
+        self.xenstore_data.update(scsiutil.update_XS_SCSIdata(
+            self.uuid, scsiutil.gen_synthetic_page_data(self.uuid)
+        ))
+
+        self.xenstore_data['storage-type'] = LinstorSR.DRIVER_TYPE
+
+        self.attached = True
+
+        return VDI.VDI.attach(self, self.sr.uuid, self.uuid)
+
+    def detach(self, sr_uuid, vdi_uuid):
+        util.SMlog('LinstorVDI.detach for {}'.format(self.uuid))
+        self.attached = False
+
+        if self.vdi_type == vhdutil.VDI_TYPE_RAW:
+            return
+
+        # The VDI is already deflated if the VHD image size + metadata is
+        # equal to the LINSTOR volume size.
+        volume_size = compute_volume_size(self.size, self.vdi_type)
+        already_deflated = self.capacity <= volume_size
+
+        if already_deflated:
+            util.SMlog(
+                'VDI {} already deflated (old volume size={}, volume size={})'
+                .format(self.uuid, self.capacity, volume_size)
+            )
+
+        need_deflate = True
+        if already_deflated:
+            need_deflate = False
+        elif self.sr._provisioning == 'thick':
+            need_deflate = False
+
+            vdi_ref = self.sr.srcmd.params['vdi_ref']
+            if self.session.xenapi.VDI.get_is_a_snapshot(vdi_ref):
+                need_deflate = True
+
+        if need_deflate:
+            try:
+                self._prepare_thin(False)
+            except Exception as e:
+                raise xs_errors.XenError(
+                    'VDIUnavailable',
+                    opterr='Failed to detach VDI during "prepare thin": {}'
+                    .format(e)
+                )
+
+    def resize(self, sr_uuid, vdi_uuid, size):
+        util.SMlog('LinstorVDI.resize for {}'.format(self.uuid))
+        if not self.sr._is_master:
+            util.SMlog('vdi_resize blocked for non-master')
+            raise xs_errors.XenError('LinstorMaster')
+
+        if self.hidden:
+            raise xs_errors.XenError('VDIUnavailable', opterr='hidden VDI')
+
+        if size < self.size:
+            util.SMlog(
+                'vdi_resize: shrinking not supported: '
+                '(current size: {}, new size: {})'.format(self.size, size)
+            )
+            raise xs_errors.XenError('VDISize', opterr='shrinking not allowed')
+
+        # Compute the virtual VHD size.
+        size = vhdutil.validate_and_round_vhd_size(long(size))
+
+        if size == self.size:
+            return VDI.VDI.get_params(self)
+
+        # Compute the LINSTOR volume size.
+        new_volume_size = compute_volume_size(size, self.vdi_type)
+        if self.vdi_type == vhdutil.VDI_TYPE_RAW:
+            old_volume_size = self.size
+        else:
+            old_volume_size = self.capacity
+            if self.sr._provisioning == 'thin':
+                # VDI is currently deflated, so keep it deflated.
+                new_volume_size = old_volume_size
+        assert new_volume_size >= old_volume_size
+
+        space_needed = new_volume_size - old_volume_size
+        self.sr._ensure_space_available(space_needed)
+
+        old_capacity = self.capacity
+        if self.vdi_type == vhdutil.VDI_TYPE_RAW:
+            self._linstor.resize(self.uuid, new_volume_size)
+        else:
+            if new_volume_size != old_volume_size:
+                inflate(
+                    self.sr._journaler, self._linstor, self.uuid, self.path,
+                    new_volume_size, old_volume_size
+                )
+            vhdutil.setSizeVirtFast(self.path, size)
+
+        # Reload size attributes.
+        self._load_this()
+
+        vdi_ref = self.sr.srcmd.params['vdi_ref']
+        self.session.xenapi.VDI.set_virtual_size(vdi_ref, str(self.size))
+        self.session.xenapi.VDI.set_physical_utilisation(
+            vdi_ref, str(self.utilisation)
+        )
+        self.sr._update_stats(self.capacity - old_capacity)
+        return VDI.VDI.get_params(self)
+
+    def clone(self, sr_uuid, vdi_uuid):
+        return self._do_snapshot(sr_uuid, vdi_uuid, VDI.SNAPSHOT_DOUBLE)
+
+    def compose(self, sr_uuid, vdi1, vdi2):
+        util.SMlog('VDI.compose for {} -> {}'.format(vdi2, vdi1))
+        if self.vdi_type != vhdutil.VDI_TYPE_VHD:
+            raise xs_errors.XenError('Unimplemented')
+
+        parent_uuid = vdi1
+        parent_path = self._linstor.get_device_path(parent_uuid)
+
+        vhdutil.setParent(self.path, parent_path, False)
+        vhdutil.setHidden(parent_path)
+        self.sr.session.xenapi.VDI.set_managed(
+            self.sr.srcmd.params['args'][0], False
+        )
+
+        if not blktap2.VDI.tap_refresh(self.session, self.sr.uuid, self.uuid):
+            raise util.SMException(
+                'Failed to refresh VDI {}'.format(self.uuid)
+            )
+
+        util.SMlog('Compose done')
+
+    def generate_config(self, sr_uuid, vdi_uuid):
+        """
+        Generate the XML config required to attach and activate
+        a VDI for use when XAPI is not running. Attach and
+        activation is handled by vdi_attach_from_config below.
+        """
+
+        util.SMlog('LinstorVDI.generate_config for {}'.format(self.uuid))
+
+        if not self.path or not util.pathexists(self.path):
+            available = False
+            # Try to refresh symlink path...
+            try:
+                self.path = self._linstor.get_device_path(vdi_uuid)
+                available = util.pathexists(self.path)
+            except Exception:
+                pass
+            if not available:
+                raise xs_errors.XenError('VDIUnavailable')
+
+        resp = {}
+        resp['device_config'] = self.sr.dconf
+        resp['sr_uuid'] = sr_uuid
+        resp['vdi_uuid'] = self.uuid
+        resp['sr_sm_config'] = self.sr.sm_config
+        resp['vdi_path'] = self.path
+        resp['command'] = 'vdi_attach_from_config'
+
+        config = xmlrpclib.dumps(tuple([resp]), 'vdi_attach_from_config')
+        return xmlrpclib.dumps((config,), "", True)
+
+    def attach_from_config(self, sr_uuid, vdi_uuid):
+        """
+        Attach and activate a VDI using config generated by
+        vdi_generate_config above. This is used for cases such as
+        the HA state-file and the redo-log.
+        """
+
+        util.SMlog('LinstorVDI.attach_from_config for {}'.format(vdi_uuid))
+
+        try:
+            if not util.pathexists(self.sr.path):
+                self.sr.attach(sr_uuid)
+
+            if not DRIVER_CONFIG['ATTACH_FROM_CONFIG_WITH_TAPDISK']:
+                return self.attach(sr_uuid, vdi_uuid)
+        except Exception:
+            util.logException('LinstorVDI.attach_from_config')
+            raise xs_errors.XenError(
+                'SRUnavailable',
+                opterr='Unable to attach from config'
+            )
+
+    def reset_leaf(self, sr_uuid, vdi_uuid):
+        if self.vdi_type != vhdutil.VDI_TYPE_VHD:
+            raise xs_errors.XenError('Unimplemented')
+
+        if not self.sr._vhdutil.has_parent(self.uuid):
+            raise util.SMException(
+                'ERROR: VDI {} has no parent, will not reset contents'
+                .format(self.uuid)
+            )
+
+        vhdutil.killData(self.path)
+
+    def _load_this(self):
+        volume_metadata = self._linstor.get_volume_metadata(self.uuid)
+        volume_info = self._linstor.get_volume_info(self.uuid)
+
+        # Contains the physical size used on all disks.
+        # When LINSTOR LVM driver is used, the size should be similar to
+        # virtual size (i.e. the LINSTOR max volume size).
+        # When LINSTOR Thin LVM driver is used, the used physical size should
+        # be lower than virtual size at creation.
+        # The physical size increases after each write in a new block.
+        self.utilisation = volume_info.physical_size
+        self.capacity = volume_info.virtual_size
+
+        if self.vdi_type == vhdutil.VDI_TYPE_RAW:
+            self.hidden = int(volume_metadata.get(HIDDEN_TAG) or 0)
+            self.size = volume_info.virtual_size
+            self.parent = ''
+        else:
+            vhd_info = self.sr._vhdutil.get_vhd_info(self.uuid)
+            self.hidden = vhd_info.hidden
+            self.size = vhd_info.sizeVirt
+            self.parent = vhd_info.parentUuid
+
+        if self.hidden:
+            self.managed = False
+
+        self.label = volume_metadata.get(NAME_LABEL_TAG) or ''
+        self.description = volume_metadata.get(NAME_DESCRIPTION_TAG) or ''
+
+        # Update sm_config_override of VDI parent class.
+        self.sm_config_override = {'vhd-parent': self.parent or None}
+
+    def _mark_hidden(self, hidden=True):
+        if self.hidden == hidden:
+            return
+
+        if self.vdi_type == vhdutil.VDI_TYPE_VHD:
+            vhdutil.setHidden(self.path, hidden)
+        else:
+            self._linstor.update_volume_metadata(self.uuid, {
+                HIDDEN_TAG: hidden
+            })
+        self.hidden = hidden
+
+    def update(self, sr_uuid, vdi_uuid):
+        xenapi = self.session.xenapi
+        vdi_ref = xenapi.VDI.get_by_uuid(self.uuid)
+
+        volume_metadata = {
+            NAME_LABEL_TAG: util.to_plain_string(
+                xenapi.VDI.get_name_label(vdi_ref)
+            ),
+            NAME_DESCRIPTION_TAG: util.to_plain_string(
+                xenapi.VDI.get_name_description(vdi_ref)
+            )
+        }
+
+        try:
+            self._linstor.update_volume_metadata(self.uuid, volume_metadata)
+        except LinstorVolumeManagerError as e:
+            if e.code == LinstorVolumeManagerError.ERR_VOLUME_NOT_EXISTS:
+                raise xs_errors.XenError(
+                    'VDIUnavailable',
+                    opterr='LINSTOR volume {} not found'.format(self.uuid)
+                )
+            raise xs_errors.XenError('VDIUnavailable', opterr=str(e))
+
+    # --------------------------------------------------------------------------
+    # Thin provisioning.
+    # --------------------------------------------------------------------------
+
+    def _prepare_thin(self, attach):
+        if self.sr._is_master:
+            if attach:
+                attach_thin(
+                    self.session, self.sr._journaler, self._linstor,
+                    self.sr.uuid, self.uuid
+                )
+            else:
+                detach_thin(
+                    self.session, self._linstor, self.sr.uuid, self.uuid
+                )
+        else:
+            fn = 'attach' if attach else 'detach'
+
+            # We assume the first pool is always the one currently in use.
+            pools = self.session.xenapi.pool.get_all()
+            master = self.session.xenapi.pool.get_master(pools[0])
+            ret = self.session.xenapi.host.call_plugin(
+                    master, self.sr.MANAGER_PLUGIN, fn, {
+                        'groupName': self.sr._group_name,
+                        'srUuid': self.sr.uuid,
+                        'vdiUuid': self.uuid
+                    }
+            )
+            util.SMlog('call-plugin returned: {}'.format(ret))
+            if ret == 'False':
+                raise xs_errors.XenError(
+                    'VDIUnavailable',
+                    opterr='Plugin {} failed'.format(self.sr.MANAGER_PLUGIN)
+                )
+
+        # Reload size attrs after inflate or deflate!
+        self._load_this()
+        self.sr._update_physical_size()
+
+        vdi_ref = self.sr.srcmd.params['vdi_ref']
+        self.session.xenapi.VDI.set_physical_utilisation(
+            vdi_ref, str(self.utilisation)
+        )
+
+        self.session.xenapi.SR.set_physical_utilisation(
+            self.sr.sr_ref, str(self.sr.physical_utilisation)
+        )
+
+    # --------------------------------------------------------------------------
+    # Generic helpers.
+    # --------------------------------------------------------------------------
+
+    def _determine_type_and_path(self):
+        """
+        Determine whether this is a RAW or a VHD VDI.
+        """
+
+        # 1. Check vdi_ref and vdi_type in config.
+        try:
+            vdi_ref = self.session.xenapi.VDI.get_by_uuid(self.uuid)
+            if vdi_ref:
+                sm_config = self.session.xenapi.VDI.get_sm_config(vdi_ref)
+                vdi_type = sm_config.get('vdi_type')
+                if vdi_type:
+                    # Update parent fields.
+                    self.vdi_type = vdi_type
+                    self.sm_config_override = sm_config
+                    self._update_device_name(
+                        self._linstor.get_volume_name(self.uuid)
+                    )
+                    return
+        except Exception:
+            pass
+
+        # 2. Otherwise use the LINSTOR volume manager directly.
+        # It's probably a new VDI created via snapshot.
+        volume_metadata = self._linstor.get_volume_metadata(self.uuid)
+        self.vdi_type = volume_metadata.get(VDI_TYPE_TAG)
+        if not self.vdi_type:
+            raise xs_errors.XenError(
+                'VDIUnavailable',
+                opterr='failed to get vdi_type in metadata'
+            )
+        self._update_device_name(
+            self._linstor.get_volume_name(self.uuid)
+        )
+
+    def _update_device_name(self, device_name):
+        self._device_name = device_name
+
+        # Mark path of VDI parent class.
+        if device_name:
+            self.path = self._linstor.build_device_path(self._device_name)
+        else:
+            self.path = None
+
+    def _create_snapshot(self, snap_uuid, snap_of_uuid=None):
+        """
+        Snapshot self and return the snapshot VDI object.
+        """
+
+        # 1. Create a new LINSTOR volume with the same size than self.
+        snap_path = self._linstor.shallow_clone_volume(
+            self.uuid, snap_uuid, persistent=False
+        )
+
+        # 2. Write the snapshot content.
+        is_raw = (self.vdi_type == vhdutil.VDI_TYPE_RAW)
+        vhdutil.snapshot(
+            snap_path, self.path, is_raw, self.MAX_METADATA_VIRT_SIZE
+        )
+
+        # 3. Get snapshot parent.
+        snap_parent = self.sr._vhdutil.get_parent(snap_uuid)
+
+        # 4. Update metadata.
+        util.SMlog('Set VDI {} metadata of snapshot'.format(snap_uuid))
+        volume_metadata = {
+            NAME_LABEL_TAG: util.to_plain_string(self.label),
+            NAME_DESCRIPTION_TAG: util.to_plain_string(self.description),
+            IS_A_SNAPSHOT_TAG: bool(snap_of_uuid),
+            SNAPSHOT_OF_TAG: snap_of_uuid,
+            SNAPSHOT_TIME_TAG: '',
+            TYPE_TAG: self.ty,
+            VDI_TYPE_TAG: vhdutil.VDI_TYPE_VHD,
+            READ_ONLY_TAG: False,
+            METADATA_OF_POOL_TAG: ''
+        }
+        self._linstor.set_volume_metadata(snap_uuid, volume_metadata)
+
+        # 5. Set size.
+        snap_vdi = LinstorVDI(self.sr, snap_uuid)
+        if not snap_vdi._exists:
+            raise xs_errors.XenError('VDISnapshot')
+
+        volume_info = self._linstor.get_volume_info(snap_uuid)
+
+        snap_vdi.size = self.sr._vhdutil.get_size_virt(snap_uuid)
+        snap_vdi.utilisation = volume_info.physical_size
+
+        # 6. Update sm config.
+        snap_vdi.sm_config = {}
+        snap_vdi.sm_config['vdi_type'] = snap_vdi.vdi_type
+        if snap_parent:
+            snap_vdi.sm_config['vhd-parent'] = snap_parent
+            snap_vdi.parent = snap_parent
+
+        snap_vdi.label = self.label
+        snap_vdi.description = self.description
+
+        self._linstor.mark_volume_as_persistent(snap_uuid)
+
+        return snap_vdi
+
+    # --------------------------------------------------------------------------
+    # Implement specific SR methods.
+    # --------------------------------------------------------------------------
+
+    def _rename(self, oldpath, newpath):
+        # TODO: I'm not sure... Used by CBT.
+        volume_uuid = self._linstor.get_volume_uuid_from_device_path(oldpath)
+        self._linstor.update_volume_name(volume_uuid, newpath)
+
+    def _do_snapshot(
+        self, sr_uuid, vdi_uuid, snap_type, secondary=None, cbtlog=None
+    ):
+        # If cbt enabled, save file consistency state.
+        if cbtlog is not None:
+            if blktap2.VDI.tap_status(self.session, vdi_uuid):
+                consistency_state = False
+            else:
+                consistency_state = True
+            util.SMlog(
+                'Saving log consistency state of {} for vdi: {}'
+                .format(consistency_state, vdi_uuid)
+            )
+        else:
+            consistency_state = None
+
+        if self.vdi_type != vhdutil.VDI_TYPE_VHD:
+            raise xs_errors.XenError('Unimplemented')
+
+        if not blktap2.VDI.tap_pause(self.session, sr_uuid, vdi_uuid):
+            raise util.SMException('Failed to pause VDI {}'.format(vdi_uuid))
+        try:
+            return self._snapshot(snap_type, cbtlog, consistency_state)
+        finally:
+            blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)
+
+    def _snapshot(self, snap_type, cbtlog=None, cbt_consistency=None):
+        util.SMlog(
+            'LinstorVDI._snapshot for {} (type {})'
+            .format(self.uuid, snap_type)
+        )
+        if not self.sr._is_master:
+            util.SMlog('vdi_snapshot blocked for non-master')
+            raise xs_errors.XenError('LinstorMaster')
+
+        # 1. Checks...
+        if self.hidden:
+            raise xs_errors.XenError('VDIClone', opterr='hidden VDI')
+
+        depth = self.sr._vhdutil.get_depth(self.uuid)
+        if depth == -1:
+            raise xs_errors.XenError(
+                'VDIUnavailable',
+                opterr='failed to get VHD depth'
+            )
+        elif depth >= vhdutil.MAX_CHAIN_SIZE:
+            raise xs_errors.XenError('SnapshotChainTooLong')
+
+        volume_path = self.path
+        if not util.pathexists(volume_path):
+            raise xs_errors.XenError(
+                'EIO',
+                opterr='IO error checking path {}'.format(volume_path)
+            )
+
+        # 2. Create base and snap uuid (if required) and a journal entry.
+        base_uuid = util.gen_uuid()
+        snap_uuid = None
+
+        if snap_type == VDI.SNAPSHOT_DOUBLE:
+            snap_uuid = util.gen_uuid()
+
+        clone_info = '{}:{}'.format(base_uuid, snap_uuid)
+
+        active_uuid = self.uuid
+        self.sr._journaler.create(
+            LinstorJournaler.CLONE, active_uuid, clone_info
+        )
+
+        try:
+            # 3. Self becomes the new base.
+            # The device path remains the same.
+            self._linstor.update_volume_uuid(self.uuid, base_uuid)
+            self.uuid = base_uuid
+            self.location = self.uuid
+            self.read_only = True
+            self.managed = False
+
+            # 4. Create snapshots (new active and snap).
+            active_vdi = self._create_snapshot(active_uuid)
+
+            snap_vdi = None
+            if snap_type == VDI.SNAPSHOT_DOUBLE:
+                snap_vdi = self._create_snapshot(snap_uuid, active_uuid)
+
+            self.label = 'base copy'
+            self.description = ''
+
+            # 5. Mark the base VDI as hidden so that it does not show up
+            # in subsequent scans.
+            self._mark_hidden()
+            self._linstor.update_volume_metadata(
+                self.uuid, {READ_ONLY_TAG: True}
+            )
+
+            # 6. We must update the new active VDI with the "paused" and
+            # "host_" properties. Why? Because the original VDI has been
+            # paused and we we must unpause it after the snapshot.
+            # See: `tap_unpause` in `blktap2.py`.
+            vdi_ref = self.session.xenapi.VDI.get_by_uuid(active_uuid)
+            sm_config = self.session.xenapi.VDI.get_sm_config(vdi_ref)
+            for key in filter(
+                lambda x: x == 'paused' or x.startswith('host_'),
+                sm_config.keys()
+            ):
+                active_vdi.sm_config[key] = sm_config[key]
+
+            # 7. Verify parent locator field of both children and
+            # delete base if unused.
+            introduce_parent = True
+            try:
+                snap_parent = None
+                if snap_vdi:
+                    snap_parent = snap_vdi.parent
+
+                if active_vdi.parent != self.uuid and (
+                    snap_type == VDI.SNAPSHOT_SINGLE or
+                    snap_type == VDI.SNAPSHOT_INTERNAL or
+                    snap_parent != self.uuid
+                ):
+                    util.SMlog(
+                        'Destroy unused base volume: {} (path={})'
+                        .format(self.uuid, self.path)
+                    )
+                    self._linstor.destroy_volume(self.uuid)
+                    introduce_parent = False
+            except Exception as e:
+                util.SMlog('Ignoring exception: {}'.format(e))
+                pass
+
+            # 8. Introduce the new VDI records.
+            if snap_vdi:
+                # If the parent is encrypted set the key_hash for the
+                # new snapshot disk.
+                vdi_ref = self.sr.srcmd.params['vdi_ref']
+                sm_config = self.session.xenapi.VDI.get_sm_config(vdi_ref)
+                # TODO: Maybe remove key_hash support.
+                if 'key_hash' in sm_config:
+                    snap_vdi.sm_config['key_hash'] = sm_config['key_hash']
+                # If we have CBT enabled on the VDI,
+                # set CBT status for the new snapshot disk.
+                if cbtlog:
+                    snap_vdi.cbt_enabled = True
+
+            if snap_vdi:
+                snap_vdi_ref = snap_vdi._db_introduce()
+                util.SMlog(
+                    'vdi_clone: introduced VDI: {} ({})'
+                    .format(snap_vdi_ref, snap_vdi.uuid)
+                )
+            if introduce_parent:
+                base_vdi_ref = self._db_introduce()
+                self.session.xenapi.VDI.set_managed(base_vdi_ref, False)
+                util.SMlog(
+                    'vdi_clone: introduced VDI: {} ({})'
+                    .format(base_vdi_ref, self.uuid)
+                )
+                self._linstor.update_volume_metadata(self.uuid, {
+                    NAME_LABEL_TAG: util.to_plain_string(self.label),
+                    NAME_DESCRIPTION_TAG: util.to_plain_string(
+                        self.description
+                    ),
+                    READ_ONLY_TAG: True,
+                    METADATA_OF_POOL_TAG: ''
+                })
+
+            # 9. Update cbt files if user created snapshot (SNAPSHOT_DOUBLE)
+            if snap_type == VDI.SNAPSHOT_DOUBLE and cbtlog:
+                try:
+                    self._cbt_snapshot(snap_uuid, cbt_consistency)
+                except Exception:
+                    # CBT operation failed.
+                    # TODO: Implement me.
+                    raise
+
+            if snap_type != VDI.SNAPSHOT_INTERNAL:
+                self.sr._update_stats(self.capacity)
+
+            # 10. Return info on the new user-visible leaf VDI.
+            ret_vdi = snap_vdi
+            if not ret_vdi:
+                ret_vdi = self
+            if not ret_vdi:
+                ret_vdi = active_vdi
+
+            vdi_ref = self.sr.srcmd.params['vdi_ref']
+            self.session.xenapi.VDI.set_sm_config(
+                vdi_ref, active_vdi.sm_config
+            )
+        except Exception as e:
+            util.logException('Failed to snapshot!')
+            try:
+                self.sr._handle_interrupted_clone(
+                    active_uuid, clone_info, force_undo=True
+                )
+                self.sr._journaler.remove(LinstorJournaler.CLONE, active_uuid)
+            except Exception as e:
+                util.SMlog(
+                    'WARNING: Failed to clean up failed snapshot: {}'
+                    .format(e)
+                )
+            raise xs_errors.XenError('VDIClone', opterr=str(e))
+
+        self.sr._journaler.remove(LinstorJournaler.CLONE, active_uuid)
+
+        return ret_vdi.get_params()
+
+# ------------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    SRCommand.run(LinstorSR, DRIVER_INFO)
+else:
+    SR.registerSR(LinstorSR)

--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -885,6 +885,48 @@
         <code>
             <name>ZFSSRDelete</name>
             <description>ZFS SR deletion error</description>
-            <value>5000</value>
+            <value>5001</value>
+        </code>
+
+        <code>
+            <name>LinstorMaster</name>
+            <description>Linstor request must come from master</description>
+            <value>5002</value>
+        </code>
+
+        <code>
+            <name>LinstorConfigHostsMissing</name>
+            <description>The request is missing the LINSTOR hosts parameter</description>
+            <value>5003</value>
+        </code>
+
+        <code>
+            <name>LinstorConfigGroupNameMissing</name>
+            <description>The request is missing the LINSTOR group name parameter</description>
+            <value>5004</value>
+        </code>
+
+        <code>
+            <name>LinstorConfigRedundancyMissing</name>
+            <description>The request is missing the LINSTOR redundancy parameter</description>
+            <value>5005</value>
+        </code>
+
+        <code>
+            <name>LinstorDisconnectedHost</name>
+            <description>Failed to join node(s)</description>
+            <value>5006</value>
+        </code>
+
+        <code>
+            <name>LinstorSRCreate</name>
+            <description>LINSTOR SR creation error</description>
+            <value>5007</value>
+        </code>
+        
+        <code>
+            <name>LinstorSRDelete</name>
+            <description>LINSTOR SR delete error</description>
+            <value>5008</value>
         </code>
 </SM-errorcodes>

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -47,7 +47,12 @@ import xs_errors
 from refcounter import RefCounter
 from ipc import IPCFlag
 from lvmanager import LVActivator
-from srmetadata import LVMMetadataHandler
+from srmetadata import LVMMetadataHandler, VDI_TYPE_TAG
+
+from linstorjournaler import LinstorJournaler
+from linstorvhdutil import LinstorVhdUtil
+from linstorvolumemanager \
+    import LinstorVolumeManager, LinstorVolumeManagerError
 
 # Disable automatic leaf-coalescing. Online leaf-coalesce is currently not 
 # possible due to lvhd_stop_using_() not working correctly. However, we leave 
@@ -643,7 +648,19 @@ class VDI:
             if child not in childList:
                 thisPrunable = False
 
-        if not self.scanError and thisPrunable:
+        # We can destroy the current VDI if all childs are hidden BUT the
+        # current VDI must be hidden too to do that!
+        # Example in this case (after a failed live leaf coalesce):
+        #
+        # SMGC: [32436] SR 07ed ('linstor-nvme-sr') (2 VDIs in 1 VHD trees):
+        # SMGC: [32436]         b5458d61(1.000G/4.127M)
+        # SMGC: [32436]             *OLD_b545(1.000G/4.129M)
+        #
+        # OLD_b545 is hidden and must be removed, but b5458d61 not.
+        # Normally we are not in this function when the delete action is
+        # executed but in `_liveLeafCoalesce`.
+
+        if not self.scanError and not self.hidden and thisPrunable:
             vdiList.append(self)
         return vdiList
 
@@ -1347,6 +1364,70 @@ class LVHDVDI(VDI):
                 lvhdutil.calcSizeLV(self.getSizeVHD())
 
 
+class LinstorVDI(VDI):
+    """Object representing a VDI in a LINSTOR SR"""
+
+    MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024  # Max VHD size.
+
+    def load(self, info=None):
+        self.parentUuid = info.parentUuid
+        self.scanError = True
+        self.parent = None
+        self.children = []
+
+        self.fileName = self.sr._linstor.get_volume_name(self.uuid)
+        self.path = self.sr._linstor.build_device_path(self.fileName)
+        if not util.pathexists(self.path):
+            raise util.SMException(
+                '{} of {} not found'
+                .format(self.fileName, self.uuid)
+            )
+
+        if not info:
+            try:
+                info = self.sr._vhdutil.get_vhd_info(self.uuid)
+            except util.SMException:
+                Util.log(
+                    ' [VDI {}: failed to read VHD metadata]'.format(self.uuid)
+                )
+                return
+
+        self.parentUuid = info.parentUuid
+        self.sizeVirt = info.sizeVirt
+        self._sizeVHD = info.sizePhys
+        self.hidden = info.hidden
+        self.scanError = False
+
+    def rename(self, uuid):
+        Util.log('Renaming {} -> {} (path={})'.format(
+            self.uuid, uuid, self.path
+        ))
+        self.sr._linstor.update_volume_uuid(self.uuid, uuid)
+        VDI.rename(self, uuid)
+
+    def delete(self):
+        if len(self.children) > 0:
+            raise util.SMException(
+                'VDI {} has children, can\'t delete'.format(self.uuid)
+            )
+        self.sr.lock()
+        try:
+            self.sr._linstor.destroy_volume(self.uuid)
+            self.sr.forgetVDI(self.uuid)
+        finally:
+            self.sr.unlock()
+        VDI.delete(self)
+
+    def _setHidden(self, hidden=True):
+        HIDDEN_TAG = 'hidden'
+
+        if self.raw:
+            self.sr._linstor.update_volume_metadata(self.uuid, {
+                HIDDEN_TAG: hidden
+            })
+            self.hidden = hidden
+        else:
+            VDI._setHidden(self, hidden)
 
 ################################################################################
 #
@@ -1403,7 +1484,8 @@ class SR:
 
     TYPE_FILE = "file"
     TYPE_LVHD = "lvhd"
-    TYPES = [TYPE_LVHD, TYPE_FILE]
+    TYPE_LINSTOR = "linstor"
+    TYPES = [TYPE_LVHD, TYPE_FILE, TYPE_LINSTOR]
 
     LOCK_RETRY_INTERVAL = 3
     LOCK_RETRY_ATTEMPTS = 20
@@ -1424,6 +1506,8 @@ class SR:
             return FileSR(uuid, xapi, createLock, force)
         elif type == SR.TYPE_LVHD:
             return LVHDSR(uuid, xapi, createLock, force)
+        elif type == SR.TYPE_LINSTOR:
+            return LinstorSR(uuid, xapi, createLock, force)
         raise util.SMException("SR type %s not recognized" % type)
     getInstance = staticmethod(getInstance)
 
@@ -2726,6 +2810,227 @@ class LVHDSR(SR):
                 vdi.fileName, vdi.uuid, slaves)
 
 
+class LinstorSR(SR):
+    TYPE = SR.TYPE_LINSTOR
+
+    def __init__(self, uuid, xapi, createLock, force):
+        SR.__init__(self, uuid, xapi, createLock, force)
+        self._master_uri = 'linstor://localhost'
+        self.path = LinstorVolumeManager.DEV_ROOT_PATH
+        self._reloadLinstor()
+
+    def deleteVDI(self, vdi):
+        self._checkSlaves(vdi)
+        SR.deleteVDI(self, vdi)
+
+    def getFreeSpace(self):
+        return self._linstor.max_volume_size_allowed
+
+    def scan(self, force=False):
+        all_vdi_info = self._scan(force)
+        for uuid, vdiInfo in all_vdi_info.iteritems():
+            # When vdiInfo is None, the VDI is RAW.
+            vdi = self.getVDI(uuid)
+            if not vdi:
+                self.logFilter.logNewVDI(uuid)
+                vdi = LinstorVDI(self, uuid, not vdiInfo)
+                self.vdis[uuid] = vdi
+            if vdiInfo:
+                vdi.load(vdiInfo)
+        self._removeStaleVDIs(all_vdi_info.keys())
+        self._buildTree(force)
+        self.logFilter.logState()
+        self._handleInterruptedCoalesceLeaf()
+
+    def _reloadLinstor(self):
+        session = self.xapi.session
+        host_ref = util.get_this_host_ref(session)
+        sr_ref = session.xenapi.SR.get_by_uuid(self.uuid)
+
+        pbd = util.find_my_pbd(session, host_ref, sr_ref)
+        if pbd is None:
+            raise util.SMException('Failed to find PBD')
+
+        dconf = session.xenapi.PBD.get_device_config(pbd)
+        group_name = dconf['group-name']
+
+        self.journaler = LinstorJournaler(
+            self._master_uri, group_name, logger=util.SMlog
+        )
+
+        self._linstor = LinstorVolumeManager(
+            self._master_uri,
+            group_name,
+            repair=True,
+            logger=util.SMlog
+        )
+        self._vhdutil = LinstorVhdUtil(session, self._linstor)
+
+    def _scan(self, force):
+        for i in range(SR.SCAN_RETRY_ATTEMPTS):
+            self._reloadLinstor()
+            error = False
+            try:
+                all_vdi_info = self._load_vdi_info()
+                for uuid, vdiInfo in all_vdi_info.iteritems():
+                    if vdiInfo and vdiInfo.error:
+                        error = True
+                        break
+                if not error:
+                    return all_vdi_info
+                Util.log('Scan error, retrying ({})'.format(i))
+            except Exception as e:
+                Util.log('Scan exception, retrying ({}): {}'.format(i, e))
+                Util.log(traceback.format_exc())
+
+        if force:
+            return all_vdi_info
+        raise util.SMException('Scan error')
+
+    def _load_vdi_info(self):
+        all_vdi_info = {}
+
+        # TODO: Ensure metadata contains the right info.
+
+        all_volume_info = self._linstor.volumes_with_info
+        volumes_metadata = self._linstor.volumes_with_metadata
+        for vdi_uuid, volume_info in all_volume_info.items():
+            try:
+                if not volume_info.name and \
+                        not list(volumes_metadata[vdi_uuid].items()):
+                    continue  # Ignore it, probably deleted.
+
+                vdi_type = volumes_metadata[vdi_uuid][VDI_TYPE_TAG]
+                if vdi_type == vhdutil.VDI_TYPE_VHD:
+                    info = self._vhdutil.get_vhd_info(vdi_uuid)
+                else:
+                    info = None
+            except Exception as e:
+                Util.log(
+                    ' [VDI {}: failed to load VDI info]: {}'
+                    .format(self.uuid, e)
+                )
+                info = vhdutil.VHDInfo(vdi_uuid)
+                info.error = 1
+            all_vdi_info[vdi_uuid] = info
+        return all_vdi_info
+
+    # TODO: Maybe implement _liveLeafCoalesce/_prepareCoalesceLeaf/
+    # _finishCoalesceLeaf/_updateSlavesOnResize like LVM plugin.
+
+    def _calcExtraSpaceNeeded(self, child, parent):
+        meta_overhead = vhdutil.calcOverheadEmpty(LinstorVDI.MAX_SIZE)
+        bitmap_overhead = vhdutil.calcOverheadBitmap(parent.sizeVirt)
+        virtual_size = LinstorVolumeManager.round_up_volume_size(
+            parent.sizeVirt + meta_overhead + bitmap_overhead
+        )
+        # TODO: Check result.
+        return virtual_size - self._linstor.get_volume_size(parent.uuid)
+
+    def _hasValidDevicePath(self, uuid):
+        try:
+            self._linstor.get_device_path(uuid)
+        except Exception:
+            # TODO: Maybe log exception.
+            return False
+        return True
+
+    def _handleInterruptedCoalesceLeaf(self):
+        entries = self.journaler.get_all(VDI.JRN_LEAF)
+        for uuid, parentUuid in entries.iteritems():
+            if self._hasValidDevicePath(parentUuid) or \
+                    self._hasValidDevicePath(self.TMP_RENAME_PREFIX + uuid):
+                self._undoInterruptedCoalesceLeaf(uuid, parentUuid)
+            else:
+                self._finishInterruptedCoalesceLeaf(uuid, parentUuid)
+            self.journaler.remove(VDI.JRN_LEAF, uuid)
+            vdi = self.getVDI(uuid)
+            if vdi:
+                vdi.ensureUnpaused()
+
+    def _undoInterruptedCoalesceLeaf(self, childUuid, parentUuid):
+        Util.log('*** UNDO LEAF-COALESCE')
+        parent = self.getVDI(parentUuid)
+        if not parent:
+            parent = self.getVDI(childUuid)
+            if not parent:
+                raise util.SMException(
+                    'Neither {} nor {} found'.format(parentUuid, childUuid)
+                )
+            Util.log(
+                'Renaming parent back: {} -> {}'.format(childUuid, parentUuid)
+            )
+            parent.rename(parentUuid)
+        util.fistpoint.activate('LVHDRT_coaleaf_undo_after_rename', self.uuid)
+
+        child = self.getVDI(childUuid)
+        if not child:
+            child = self.getVDI(self.TMP_RENAME_PREFIX + childUuid)
+            if not child:
+                raise util.SMException(
+                    'Neither {} nor {} found'.format(
+                        childUuid, self.TMP_RENAME_PREFIX + childUuid
+                    )
+                )
+            Util.log('Renaming child back to {}'.format(childUuid))
+            child.rename(childUuid)
+            Util.log('Updating the VDI record')
+            child.setConfig(VDI.DB_VHD_PARENT, parentUuid)
+            child.setConfig(VDI.DB_VDI_TYPE, vhdutil.VDI_TYPE_VHD)
+            util.fistpoint.activate(
+                'LVHDRT_coaleaf_undo_after_rename2', self.uuid
+            )
+
+        # TODO: Maybe deflate here.
+
+        if child.hidden:
+            child._setHidden(False)
+        if not parent.hidden:
+            parent._setHidden(True)
+        self._updateSlavesOnUndoLeafCoalesce(parent, child)
+        util.fistpoint.activate('LVHDRT_coaleaf_undo_end', self.uuid)
+        Util.log('*** leaf-coalesce undo successful')
+        if util.fistpoint.is_active('LVHDRT_coaleaf_stop_after_recovery'):
+            child.setConfig(VDI.DB_LEAFCLSC, VDI.LEAFCLSC_DISABLED)
+
+    def _finishInterruptedCoalesceLeaf(self, childUuid, parentUuid):
+        Util.log('*** FINISH LEAF-COALESCE')
+        vdi = self.getVDI(childUuid)
+        if not vdi:
+            raise util.SMException('VDI {} not found'.format(childUuid))
+        # TODO: Maybe inflate.
+        try:
+            self.forgetVDI(parentUuid)
+        except XenAPI.Failure:
+            pass
+        self._updateSlavesOnResize(vdi)
+        util.fistpoint.activate('LVHDRT_coaleaf_finish_end', self.uuid)
+        Util.log('*** finished leaf-coalesce successfully')
+
+    def _checkSlaves(self, vdi):
+        try:
+            states = self._linstor.get_usage_states(vdi.uuid)
+            for node_name, state in states.items():
+                self._checkSlave(node_name, vdi, state)
+        except LinstorVolumeManagerError as e:
+            if e.code != LinstorVolumeManagerError.ERR_VOLUME_NOT_EXISTS:
+                raise
+
+    @staticmethod
+    def _checkSlave(node_name, vdi, state):
+        # If state is None, LINSTOR doesn't know the host state
+        # (bad connection?).
+        if state is None:
+            raise util.SMException(
+                'Unknown state for VDI {} on {}'.format(vdi.uuid, node_name)
+            )
+
+        if state:
+            raise util.SMException(
+                'VDI {} is in use on {}'.format(vdi.uuid, node_name)
+            )
+
+
 ################################################################################
 #
 #  Helpers
@@ -2766,7 +3071,9 @@ def normalizeType(type):
         "xfs", "zfs"
     ]:
         type = SR.TYPE_FILE
-    if not type in SR.TYPES:
+    if type in ["linstor"]:
+        type = SR.TYPE_LINSTOR
+    if type not in SR.TYPES:
         raise util.SMException("Unsupported SR type: %s" % type)
     return type
 

--- a/drivers/linstor-manager
+++ b/drivers/linstor-manager
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2020  Vates SAS - ronan.abhamon@vates.fr
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import distutils.util
+import subprocess
+import sys
+import XenAPIPlugin
+
+sys.path.append('/opt/xensource/sm/')
+from linstorjournaler import LinstorJournaler
+from linstorvolumemanager import LinstorVolumeManager
+import json
+import LinstorSR
+import util
+import vhdutil
+
+
+FIREWALL_PORT_SCRIPT = '/etc/xapi.d/plugins/firewall-port'
+LINSTOR_PORTS = [3366, 3370, 3376, 3377, '7000:8000']
+
+
+def get_linstor_uri(session):
+    return 'linstor://{}'.format(util.get_master_rec(session)['address'])
+
+
+def update_port(port, open):
+    fn = 'open' if open else 'close'
+    args = (
+        FIREWALL_PORT_SCRIPT, fn, str(port), 'tcp'
+    )
+
+    (ret, out, err) = util.doexec(args)
+    if ret == 0:
+        return
+    raise Exception('Failed to {} port: {} {}'.format(fn, out, err))
+
+
+def update_all_ports(open):
+    for port in LINSTOR_PORTS:
+        update_port(port, open)
+
+
+def update_service(start):
+    fn = 'enable' if start else 'disable'
+    args = ('systemctl', fn, '--now', 'linstor-satellite')
+    (ret, out, err) = util.doexec(args)
+    if ret == 0:
+        return
+    raise Exception('Failed to {} satellite: {} {}'.format(fn, out, err))
+
+
+def enable(session, args):
+    try:
+        enabled = distutils.util.strtobool(args['enabled'])
+        update_all_ports(open=enabled)
+        update_service(start=enabled)
+        return str(True)
+    except Exception as e:
+        util.SMlog('linstor-manager:disable error: {}'.format(e))
+    return str(False)
+
+
+def attach(session, args):
+    try:
+        sr_uuid = args['srUuid']
+        vdi_uuid = args['vdiUuid']
+        group_name = args['groupName']
+
+        linstor_uri = get_linstor_uri(session)
+        journaler = LinstorJournaler(
+            linstor_uri, group_name, logger=util.SMlog
+        )
+        linstor = LinstorVolumeManager(
+            linstor_uri,
+            group_name,
+            logger=util.SMlog
+        )
+        LinstorSR.attach_thin(session, journaler, linstor, sr_uuid, vdi_uuid)
+        return str(True)
+    except Exception as e:
+        util.SMlog('linstor-manager:attach error: {}'.format(e))
+    return str(False)
+
+
+def detach(session, args):
+    try:
+        sr_uuid = args['srUuid']
+        vdi_uuid = args['vdiUuid']
+        group_name = args['groupName']
+
+        linstor = LinstorVolumeManager(
+            get_linstor_uri(session),
+            group_name,
+            logger=util.SMlog
+        )
+        LinstorSR.detach_thin(session, linstor, sr_uuid, vdi_uuid)
+        return str(True)
+    except Exception as e:
+        util.SMlog('linstor-manager:detach error: {}'.format(e))
+    return str(False)
+
+
+def check(session, args):
+    try:
+        device_path = args['devicePath']
+        return str(vhdutil.check(device_path))
+    except Exception as e:
+        util.SMlog('linstor-manager:check error: {}'.format(e))
+        raise
+
+
+def get_vhd_info(session, args):
+    try:
+        device_path = args['devicePath']
+        group_name = args['groupName']
+        include_parent = distutils.util.strtobool(args['includeParent'])
+
+        linstor = LinstorVolumeManager(
+            get_linstor_uri(session),
+            group_name,
+            logger=util.SMlog
+        )
+
+        def extract_uuid(device_path):
+            # TODO: Remove new line in the vhdutil module. Not here.
+            return linstor.get_volume_uuid_from_device_path(
+                device_path.rstrip('\n')
+            )
+
+        vhd_info = vhdutil.getVHDInfo(
+            device_path, extract_uuid, include_parent
+        )
+        return json.dumps(vhd_info.__dict__)
+    except Exception as e:
+        util.SMlog('linstor-manager:get_vhd_info error: {}'.format(e))
+        raise
+
+
+def has_parent(session, args):
+    try:
+        device_path = args['devicePath']
+        return str(vhdutil.hasParent(device_path))
+    except Exception as e:
+        util.SMlog('linstor-manager:has_parent error: {}'.format(e))
+        raise
+
+
+def get_parent(session, args):
+    try:
+        device_path = args['devicePath']
+        group_name = args['groupName']
+
+        linstor = LinstorVolumeManager(
+            get_linstor_uri(session),
+            group_name,
+            logger=util.SMlog
+        )
+
+        def extract_uuid(device_path):
+            # TODO: Remove new line in the vhdutil module. Not here.
+            return linstor.get_volume_uuid_from_device_path(
+                device_path.rstrip('\n')
+            )
+
+        return vhdutil.getParent(device_path, extract_uuid)
+    except Exception as e:
+        util.SMlog('linstor-manager:get_parent error: {}'.format(e))
+        raise
+
+
+def get_size_virt(session, args):
+    try:
+        device_path = args['devicePath']
+        return str(vhdutil.getSizeVirt(device_path))
+    except Exception as e:
+        util.SMlog('linstor-manager:get_size_virt error: {}'.format(e))
+        raise
+
+
+def get_size_phys(session, args):
+    try:
+        device_path = args['devicePath']
+        return str(vhdutil.getSizePhys(device_path))
+    except Exception as e:
+        util.SMlog('linstor-manager:get_size_phys error: {}'.format(e))
+        raise
+
+
+def get_depth(session, args):
+    try:
+        device_path = args['devicePath']
+        return str(vhdutil.getDepth(device_path))
+    except Exception as e:
+        util.SMlog('linstor-manager:get_depth error: {}'.format(e))
+        raise
+
+
+def get_key_hash(session, args):
+    try:
+        device_path = args['devicePath']
+        return vhdutil.getKeyHash(device_path) or ''
+    except Exception as e:
+        util.SMlog('linstor-manager:get_key_hash error: {}'.format(e))
+        raise
+
+
+if __name__ == '__main__':
+    XenAPIPlugin.dispatch({
+        'enable': enable,
+        'attach': attach,
+        'detach': detach,
+        'check': check,
+        'getVHDInfo': get_vhd_info,
+        'hasParent': has_parent,
+        'getParent': get_parent,
+        'getSizeVirt': get_size_virt,
+        'getSizePhys': get_size_phys,
+        'getDepth': get_depth,
+        'getKeyHash': get_key_hash
+    })

--- a/drivers/linstorjournaler.py
+++ b/drivers/linstorjournaler.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2020  Vates SAS - ronan.abhamon@vates.fr
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+from linstorvolumemanager import LinstorVolumeManager
+import linstor
+import re
+
+
+class LinstorJournalerError(Exception):
+    pass
+
+# ==============================================================================
+
+
+class LinstorJournaler:
+    """
+    Simple journaler that uses LINSTOR properties for persistent "storage".
+    A journal is a id-value pair, and there can be only one journal for a
+    given id. An identifier is juste a transaction name.
+    """
+
+    REG_TYPE = re.compile('^([^/]+)$')
+    REG_TRANSACTION = re.compile('^[^/]+/([^/]+)$')
+
+    """
+    Types of transaction in the journal.
+    """
+    CLONE = 'clone'
+    INFLATE = 'inflate'
+
+    @staticmethod
+    def default_logger(*args):
+        print(args)
+
+    def __init__(self, uri, group_name, logger=default_logger.__func__):
+        self._namespace = '{}journal/'.format(
+            LinstorVolumeManager._build_sr_namespace()
+        )
+        self._journal = linstor.KV(
+            LinstorVolumeManager._build_group_name(group_name),
+            uri=uri,
+            namespace=self._namespace
+        )
+        self._logger = logger
+
+    def create(self, type, identifier, value):
+        # TODO: Maybe rename to 'add' in the future (in Citrix code too).
+
+        key = self._get_key(type, identifier)
+
+        # 1. Ensure transaction doesn't exist.
+        current_value = self.get(type, identifier)
+        if current_value is not None:
+            raise LinstorJournalerError(
+                'Journal transaction already exists for \'{}:{}\': {}'
+                .format(type, identifier, current_value)
+            )
+
+        # 2. Write!
+        try:
+            self._reset_namespace()
+            self._logger(
+                'Create journal transaction \'{}:{}\''.format(type, identifier)
+            )
+            self._journal[key] = str(value)
+        except Exception as e:
+            try:
+                self._journal.pop(key, 'empty')
+            except Exception as e2:
+                self._logger(
+                    'Failed to clean up failed journal write: {} (Ignored)'
+                    .format(e2)
+                )
+
+            raise LinstorJournalerError(
+                'Failed to write to journal: {}'.format(e)
+            )
+
+    def remove(self, type, identifier):
+        key = self._get_key(type, identifier)
+        try:
+            self._reset_namespace()
+            self._logger(
+                'Destroy journal transaction \'{}:{}\''
+                .format(type, identifier)
+            )
+            self._journal.pop(key)
+        except Exception as e:
+            raise LinstorJournalerError(
+                'Failed to remove transaction \'{}:{}\': {}'
+                .format(type, identifier, e)
+            )
+
+    def get(self, type, identifier):
+        return self._journal.get(self._get_key(type, identifier))
+
+    def get_all(self, type):
+        entries = {}
+
+        self._journal.namespace = self._namespace + '{}/'.format(type)
+        for (key, value) in self._journal.items():
+            res = self.REG_TYPE.match(key)
+            if res:
+                identifier = res.groups()[0]
+                entries[identifier] = value
+        return entries
+
+    # Added to compatibility with Citrix API.
+    def getAll(self, type):
+        return self.get_all(type)
+
+    def has_entries(self, identifier):
+        self._reset_namespace()
+        for (key, value) in self._journal.items():
+            res = self.REG_TRANSACTION.match(key)
+            if res:
+                current_identifier = res.groups()[0]
+                if current_identifier == identifier:
+                    return True
+        return False
+
+    # Added to compatibility with Citrix API.
+    def hasJournals(self, identifier):
+        return self.has_entries(identifier)
+
+    def _reset_namespace(self):
+        self._journal.namespace = self._namespace
+
+    @staticmethod
+    def _get_key(type, identifier):
+        return '{}/{}'.format(type, identifier)

--- a/drivers/linstorvhdutil.py
+++ b/drivers/linstorvhdutil.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2020  Vates SAS - ronan.abhamon@vates.fr
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import distutils.util
+import json
+import util
+import vhdutil
+import xs_errors
+
+MANAGER_PLUGIN = 'linstor-manager'
+
+
+def linstorhostcall(local_method, remote_method):
+    def decorated(func):
+        def wrapper(*args, **kwargs):
+            self = args[0]
+            vdi_uuid = args[1]
+
+            device_path = self._linstor.build_device_path(
+                self._linstor.get_volume_name(vdi_uuid)
+            )
+
+            # A. Try a call using directly the DRBD device to avoid
+            # remote request.
+            try:
+                return local_method(device_path, *args[2:], **kwargs)
+            except Exception:
+                # TODO: Check errno?
+                pass
+
+            # B. Execute the plugin on master or slave.
+            def exec_remote_method():
+                host_ref = self._get_readonly_host(vdi_uuid, device_path)
+                args = {
+                    'devicePath': device_path,
+                    'groupName': self._linstor.group_name
+                }
+                args.update(**kwargs)
+
+                try:
+                    response = self._session.xenapi.host.call_plugin(
+                        host_ref, MANAGER_PLUGIN, remote_method, args
+                    )
+                except Exception as e:
+                    util.SMlog('call-plugin ({}) exception: {}'.format(
+                        remote_method, e
+                    ))
+                    raise
+
+                util.SMlog('call-plugin ({}) returned: {}'.format(
+                    remote_method, response
+                ))
+                if response == 'False':
+                    raise xs_errors.XenError(
+                        'VDIUnavailable',
+                        opterr='Plugin {} failed'.format(MANAGER_PLUGIN)
+                    )
+                kwargs['response'] = response
+
+            util.retry(exec_remote_method, 5, 3)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorated
+
+
+class LinstorVhdUtil:
+    def __init__(self, session, linstor):
+        self._session = session
+        self._linstor = linstor
+
+    @linstorhostcall(vhdutil.check, 'check')
+    def check(self, vdi_uuid, **kwargs):
+        return distutils.util.strtobool(kwargs['response'])
+
+    def get_vhd_info(self, vdi_uuid, include_parent=True):
+        kwargs = {'includeParent': str(include_parent)}
+        return self._get_vhd_info(vdi_uuid, self._extract_uuid, **kwargs)
+
+    @linstorhostcall(vhdutil.getVHDInfo, 'getVHDInfo')
+    def _get_vhd_info(self, vdi_uuid, *args, **kwargs):
+        obj = json.loads(kwargs['response'])
+
+        vhd_info = vhdutil.VHDInfo(vdi_uuid)
+        vhd_info.sizeVirt = obj['sizeVirt']
+        vhd_info.sizePhys = obj['sizePhys']
+        if 'parentPath' in obj:
+            vhd_info.parentPath = obj['parentPath']
+            vhd_info.parentUuid = obj['parentUuid']
+        vhd_info.hidden = obj['hidden']
+        vhd_info.path = obj['path']
+
+        return vhd_info
+
+    @linstorhostcall(vhdutil.hasParent, 'hasParent')
+    def has_parent(self, vdi_uuid, **kwargs):
+        return distutils.util.strtobool(kwargs['response'])
+
+    def get_parent(self, vdi_uuid):
+        return self._get_parent(vdi_uuid, self._extract_uuid)
+
+    @linstorhostcall(vhdutil.getParent, 'getParent')
+    def _get_parent(self, vdi_uuid, *args, **kwargs):
+        return kwargs['response']
+
+    @linstorhostcall(vhdutil.getSizeVirt, 'getSizeVirt')
+    def get_size_virt(self, vdi_uuid, **kwargs):
+        return int(kwargs['response'])
+
+    @linstorhostcall(vhdutil.getSizePhys, 'getSizePhys')
+    def get_size_phys(self, vdi_uuid, **kwargs):
+        return int(kwargs['response'])
+
+    @linstorhostcall(vhdutil.getDepth, 'getDepth')
+    def get_depth(self, vdi_uuid, **kwargs):
+        return int(kwargs['response'])
+
+    @linstorhostcall(vhdutil.getKeyHash, 'getKeyHash')
+    def get_key_hash(self, vdi_uuid, **kwargs):
+        return kwargs['response'] or None
+
+    # --------------------------------------------------------------------------
+    # Helpers.
+    # --------------------------------------------------------------------------
+
+    def _extract_uuid(self, device_path):
+        # TODO: Remove new line in the vhdutil module. Not here.
+        return self._linstor.get_volume_uuid_from_device_path(
+            device_path.rstrip('\n')
+        )
+
+    def _get_readonly_host(self, vdi_uuid, device_path):
+        """
+        When vhd-util is called to fetch VDI info we must find a
+        diskfull DRBD disk to read the data. It's the goal of this function.
+        Why? Because when a VHD is open in RO mode, the LVM layer is used
+        directly to bypass DRBD verifications (we can have only one process
+        that reads/writes to disk with DRBD devices).
+        """
+
+        node_names = self._linstor.find_up_to_date_diskfull_nodes(vdi_uuid)
+        if not node_names:
+            raise xs_errors.XenError(
+                'VDIUnavailable',
+                opterr='Unable to find diskfull node: {} (path={})'
+                .format(vdi_uuid, device_path)
+            )
+
+        hosts = self._session.xenapi.host.get_all_records()
+        for host_ref, host_record in hosts.items():
+            if host_record['hostname'] in node_names:
+                return host_ref
+
+        raise xs_errors.XenError(
+            'VDIUnavailable',
+            opterr='Unable to find a valid host from VDI: {} (path={})'
+            .format(vdi_uuid, device_path)
+        )

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1,0 +1,1524 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2020  Vates SAS - ronan.abhamon@vates.fr
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+import json
+import linstor
+import os.path
+import re
+import socket
+import util
+
+
+def round_up(value, divisor):
+    assert divisor
+    divisor = int(divisor)
+    return int((int(value) + divisor - 1) / divisor) * divisor
+
+
+def round_down(value, divisor):
+    assert divisor
+    value = int(value)
+    return value - (value % int(divisor))
+
+
+class LinstorVolumeManagerError(Exception):
+    ERR_GENERIC = 0,
+    ERR_VOLUME_EXISTS = 1,
+    ERR_VOLUME_NOT_EXISTS = 2
+
+    def __init__(self, message, code=ERR_GENERIC):
+        super(LinstorVolumeManagerError, self).__init__(message)
+        self._code = code
+
+    @property
+    def code(self):
+        return self._code
+
+# ==============================================================================
+
+# Note:
+# If a storage pool is not accessible after a network change:
+# linstor node interface modify <NODE> default --ip <IP>
+
+
+class LinstorVolumeManager(object):
+    """
+    API to manager LINSTOR volumes in XCP-ng.
+    A volume in this context is a physical part of the storage layer.
+    """
+
+    DEV_ROOT_PATH = '/dev/drbd/by-res/'
+
+    # Default LVM extent size.
+    BLOCK_SIZE = 4 * 1024 * 1024
+
+    # List of volume properties.
+    PROP_METADATA = 'metadata'
+    PROP_NOT_EXISTS = 'not-exists'
+    PROP_VOLUME_NAME = 'volume-name'
+
+    # Used when volume uuid is being updated.
+    PROP_UPDATING_UUID_SRC = 'updating-uuid-src'
+
+    # States of property PROP_NOT_EXISTS.
+    STATE_EXISTS = '0'
+    STATE_NOT_EXISTS = '1'
+    STATE_CREATING = '2'
+
+    # Property namespaces.
+    NAMESPACE_SR = 'xcp/sr'
+    NAMESPACE_VOLUME = 'volume'
+
+    # Regex to match properties.
+    REG_PROP = '^([^/]+)/{}$'
+
+    REG_METADATA = re.compile(REG_PROP.format(PROP_METADATA))
+    REG_NOT_EXISTS = re.compile(REG_PROP.format(PROP_NOT_EXISTS))
+    REG_VOLUME_NAME = re.compile(REG_PROP.format(PROP_VOLUME_NAME))
+    REG_UPDATING_UUID_SRC = re.compile(REG_PROP.format(PROP_UPDATING_UUID_SRC))
+
+    # Prefixes of SR/VOLUME in the LINSTOR DB.
+    # A LINSTOR (resource, group, ...) name cannot start with a number.
+    # So we add a prefix behind our SR/VOLUME uuids.
+    PREFIX_SR = 'xcp-sr-'
+    PREFIX_VOLUME = 'xcp-volume-'
+
+    @staticmethod
+    def default_logger(*args):
+        print(args)
+
+    # --------------------------------------------------------------------------
+    # API.
+    # --------------------------------------------------------------------------
+
+    class VolumeInfo(object):
+        __slots__ = (
+            'name',
+            'physical_size',  # Total physical size used by this volume on
+                              # all disks.
+            'virtual_size'    # Total virtual available size of this volume
+                              # (i.e. the user size at creation).
+        )
+
+        def __init__(self, name):
+            self.name = name
+            self.physical_size = 0
+            self.virtual_size = 0
+
+        def __repr__(self):
+            return 'VolumeInfo("{}", {}, {})'.format(
+                self.name, self.physical_size, self.virtual_size
+            )
+
+    # --------------------------------------------------------------------------
+
+    def __init__(
+        self, uri, group_name, repair=False, logger=default_logger.__func__
+    ):
+        """
+        Create a new LinstorApi object.
+        :param str uri: URI to communicate with the LINSTOR controller.
+        :param str group_name: The SR goup name to use.
+        :param bool repair: If true we try to remove bad volumes due to a crash
+        or unexpected behavior.
+        :param function logger: Function to log messages.
+        """
+
+        self._uri = uri
+        self._linstor = self._create_linstor_instance(uri)
+        self._base_group_name = group_name
+
+        # Ensure group exists.
+        group_name = self._build_group_name(group_name)
+        groups = self._linstor.resource_group_list_raise([group_name])
+        groups = groups.resource_groups
+        if not groups:
+            raise LinstorVolumeManagerError(
+                'Unable to find `{}` Linstor SR'.format(group_name)
+            )
+
+        # Ok. ;)
+        self._logger = logger
+        self._redundancy = groups[0].select_filter.place_count
+        self._group_name = group_name
+        self._build_volumes(repair=repair)
+
+    @property
+    def group_name(self):
+        """
+        Give the used group name.
+        :return: The group name.
+        :rtype: str
+        """
+        return self._base_group_name
+
+    @property
+    def volumes(self):
+        """
+        Give the volumes uuid set.
+        :return: The volumes uuid set.
+        :rtype: set(str)
+        """
+        return self._volumes
+
+    @property
+    def volumes_with_name(self):
+        """
+        Give a volume dictionnary that contains names actually owned.
+        :return: A volume/name dict.
+        :rtype: dict(str, str)
+        """
+        return self._get_volumes_by_property(self.REG_VOLUME_NAME)
+
+    @property
+    def volumes_with_info(self):
+        """
+        Give a volume dictionnary that contains VolumeInfos.
+        :return: A volume/VolumeInfo dict.
+        :rtype: dict(str, VolumeInfo)
+        """
+
+        volumes = {}
+
+        all_volume_info = self._get_volumes_info()
+        volume_names = self.volumes_with_name
+        for volume_uuid, volume_name in volume_names.items():
+            if volume_name:
+                volume_info = all_volume_info.get(volume_name)
+                if volume_info:
+                    volumes[volume_uuid] = volume_info
+                    continue
+
+            # Well I suppose if this volume is not available,
+            # LINSTOR has been used directly without using this API.
+            volumes[volume_uuid] = self.VolumeInfo('')
+
+        return volumes
+
+    @property
+    def volumes_with_metadata(self):
+        """
+        Give a volume dictionnary that contains metadata.
+        :return: A volume/metadata dict.
+        :rtype: dict(str, dict)
+        """
+
+        volumes = {}
+
+        metadata = self._get_volumes_by_property(self.REG_METADATA)
+        for volume_uuid, volume_metadata in metadata.items():
+            if volume_metadata:
+                volume_metadata = json.loads(volume_metadata)
+                if isinstance(volume_metadata, dict):
+                    volumes[volume_uuid] = volume_metadata
+                    continue
+                raise LinstorVolumeManagerError(
+                    'Expected dictionary in volume metadata: {}'
+                    .format(volume_uuid)
+                )
+
+            volumes[volume_uuid] = {}
+
+        return volumes
+
+    @property
+    def max_volume_size_allowed(self):
+        """
+        Give the max volume size currently available in B.
+        :return: The current size.
+        :rtype: int
+        """
+
+        candidates = self._find_best_size_candidates()
+        if not candidates:
+            raise LinstorVolumeManagerError(
+                'Failed to get max volume size allowed'
+            )
+
+        size = candidates[0].max_volume_size
+        if size < 0:
+            raise LinstorVolumeManagerError(
+                'Invalid max volume size allowed given: {}'.format(size)
+            )
+        return self.round_down_volume_size(size * 1024)
+
+    @property
+    def physical_size(self):
+        """
+        Give the total physical size of the SR.
+        :return: The physical size.
+        :rtype: int
+        """
+        return self._compute_size('total_capacity')
+
+    @property
+    def physical_free_size(self):
+        """
+        Give the total free physical size of the SR.
+        :return: The physical free size.
+        :rtype: int
+        """
+        return self._compute_size('free_capacity')
+
+    @property
+    def total_allocated_volume_size(self):
+        """
+        Give the sum of all created volumes.
+        :return: The physical required size to use the volumes.
+        :rtype: int
+        """
+
+        size = 0
+        for resource in self._linstor.resource_list_raise().resources:
+            for volume in resource.volumes:
+                # We ignore diskless pools of the form "DfltDisklessStorPool".
+                if volume.storage_pool_name == self._group_name:
+                    current_size = volume.usable_size
+                    if current_size < 0:
+                        raise LinstorVolumeManagerError(
+                           'Failed to get usable size of `{}` on `{}`'
+                           .format(resource.name, volume.storage_pool_name)
+                        )
+                    size += current_size
+        return size * 1024
+
+    @property
+    def metadata(self):
+        """
+        Get the metadata of the SR.
+        :return: Dictionary that contains metadata.
+        :rtype: dict(str, dict)
+        """
+
+        sr_properties = self._get_sr_properties()
+        metadata = sr_properties.get(self.PROP_METADATA)
+        if metadata is not None:
+            metadata = json.loads(metadata)
+            if isinstance(metadata, dict):
+                return metadata
+            raise LinstorVolumeManagerError(
+                'Expected dictionary in SR metadata: {}'.format(
+                    self._group_name
+                )
+            )
+
+        return {}
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Set the metadata of the SR.
+        :param dict metadata: Dictionary that contains metadata.
+        """
+
+        assert isinstance(metadata, dict)
+        sr_properties = self._get_sr_properties()
+        sr_properties[self.PROP_METADATA] = json.dumps(metadata)
+
+    @property
+    def disconnected_hosts(self):
+        """
+        Get the list of disconnected hosts.
+        :return: Set that contains disconnected hosts.
+        :rtype: set(str)
+        """
+
+        pools = self._linstor.storage_pool_list_raise(
+            filter_by_stor_pools=[self._group_name]
+        ).storage_pools
+
+        disconnected_hosts = set()
+        for pool in pools:
+            for report in pool.reports:
+                if report.ret_code & linstor.consts.WARN_NOT_CONNECTED == \
+                        linstor.consts.WARN_NOT_CONNECTED:
+                    disconnected_hosts.add(pool.node_name)
+                    break
+        return disconnected_hosts
+
+    def check_volume_exists(self, volume_uuid):
+        """
+        Check if a volume exists in the SR.
+        :return: True if volume exists.
+        :rtype: bool
+        """
+        return volume_uuid in self._volumes
+
+    def create_volume(self, volume_uuid, size, persistent=True):
+        """
+        Create a new volume on the SR.
+        :param str volume_uuid: The volume uuid to use.
+        :param int size: volume size in B.
+        :param bool persistent: If false the volume will be unavailable
+        on the next constructor call LinstorSR(...).
+        :return: The current device path of the volume.
+        :rtype: str
+        """
+
+        self._logger('Creating LINSTOR volume {}...'.format(volume_uuid))
+        volume_name = self.build_volume_name(util.gen_uuid())
+        volume_properties = self._create_volume_with_properties(
+            volume_uuid, volume_name, size, place_resources=True
+        )
+
+        try:
+            self._logger(
+                'Find device path of LINSTOR volume {}...'.format(volume_uuid)
+            )
+            device_path = self._find_device_path(volume_uuid, volume_name)
+            if persistent:
+                volume_properties[self.PROP_NOT_EXISTS] = self.STATE_EXISTS
+            self._volumes.add(volume_uuid)
+            self._logger(
+                'LINSTOR volume {} created!'.format(volume_uuid)
+            )
+            return device_path
+        except Exception:
+            self._force_destroy_volume(volume_uuid, volume_properties)
+            raise
+
+    def mark_volume_as_persistent(self, volume_uuid):
+        """
+        Mark volume as persistent if created with persistent=False.
+        :param str volume_uuid: The volume uuid to mark.
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+
+        # Mark volume as persistent.
+        volume_properties = self._get_volume_properties(volume_uuid)
+        volume_properties[self.PROP_NOT_EXISTS] = self.STATE_EXISTS
+
+    def destroy_volume(self, volume_uuid):
+        """
+        Destroy a volume.
+        :param str volume_uuid: The volume uuid to destroy.
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+
+        # Mark volume as destroyed.
+        volume_properties = self._get_volume_properties(volume_uuid)
+        volume_properties[self.PROP_NOT_EXISTS] = self.STATE_NOT_EXISTS
+
+        self._volumes.remove(volume_uuid)
+        self._destroy_volume(volume_uuid, volume_properties)
+
+    def introduce_volume(self, volume_uuid):
+        pass  # TODO: Implement me.
+
+    def resize_volume(self, volume_uuid, new_size):
+        """
+        Resize a volume.
+        :param str volume_uuid: The volume uuid to resize.
+        :param int new_size: New size in B.
+        """
+
+        volume_name = self.get_volume_name(volume_uuid)
+        new_size = self.round_up_volume_size(new_size)
+
+        result = self._linstor.volume_dfn_modify(
+            rsc_name=volume_name,
+            volume_nr=0,
+            size=new_size / 1024
+        )
+        error_str = self._get_error_str(result)
+        if error_str:
+            raise LinstorVolumeManagerError(
+                'Could not resize volume `{}` from SR `{}`: {}'
+                .format(volume_uuid, self._group_name, error_str)
+            )
+
+    def get_volume_name(self, volume_uuid):
+        """
+        Get the name of a particular volume.
+        :param str volume_uuid: The volume uuid of the name to get.
+        :return: The volume name.
+        :rtype: str
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+        volume_properties = self._get_volume_properties(volume_uuid)
+        volume_name = volume_properties.get(self.PROP_VOLUME_NAME)
+        if volume_name:
+            return volume_name
+        raise LinstorVolumeManagerError(
+            'Failed to get volume name of {}'.format(volume_uuid)
+        )
+
+    def get_volume_size(self, volume_uuid):
+        """
+        Get the size of a particular volume.
+        :param str volume_uuid: The volume uuid of the size to get.
+        :return: The volume size.
+        :rtype: int
+        """
+
+        volume_name = self.get_volume_name(volume_uuid)
+        dfns = self._linstor.resource_dfn_list_raise(
+            query_volume_definitions=True,
+            filter_by_resource_definitions=[volume_name]
+        ).resource_definitions
+
+        size = dfns[0].volume_definitions[0].size
+        if size < 0:
+            raise LinstorVolumeManagerError(
+                'Failed to get volume size of: {}'.format(volume_uuid)
+            )
+        return size * 1024
+
+    def get_volume_info(self, volume_uuid):
+        """
+        Get the volume info of a particular volume.
+        :param str volume_uuid: The volume uuid of the volume info to get.
+        :return: The volume info.
+        :rtype: VolumeInfo
+        """
+
+        volume_name = self.get_volume_name(volume_uuid)
+        return self._get_volumes_info(filter=[volume_name])[volume_name]
+
+    def get_device_path(self, volume_uuid):
+        """
+        Get the dev path of a volume.
+        :param str volume_uuid: The volume uuid to get the dev path.
+        :return: The current device path of the volume.
+        :rtype: str
+        """
+
+        volume_name = self.get_volume_name(volume_uuid)
+        return self._find_device_path(volume_uuid, volume_name)
+
+    def get_volume_uuid_from_device_path(self, device_path):
+        """
+        Get the volume uuid of a device_path.
+        :param str device_path: The dev path to find the volume uuid.
+        :return: The volume uuid of the local device path.
+        :rtype: str
+        """
+
+        expected_volume_name = \
+            self.get_volume_name_from_device_path(device_path)
+
+        volume_names = self.volumes_with_name
+        for volume_uuid, volume_name in volume_names.items():
+            if volume_name == expected_volume_name:
+                return volume_uuid
+
+        raise LinstorVolumeManagerError(
+            'Unable to find volume uuid from dev path `{}`'.format(device_path)
+        )
+
+    def get_volume_name_from_device_path(self, device_path):
+        """
+        Get the volume name of a device_path on the current host.
+        :param str device_path: The dev path to find the volume name.
+        :return: The volume name of the local device path.
+        :rtype: str
+        """
+
+        node_name = socket.gethostname()
+        resources = self._linstor.resource_list_raise(
+            filter_by_nodes=[node_name]
+        ).resources
+
+        real_device_path = os.path.realpath(device_path)
+        for resource in resources:
+            if resource.volumes[0].device_path == real_device_path:
+                return resource.name
+
+        raise LinstorVolumeManagerError(
+            'Unable to find volume name from dev path `{}`'
+            .format(device_path)
+        )
+
+    def update_volume_uuid(self, volume_uuid, new_volume_uuid):
+        """
+        Change the uuid of a volume.
+        :param str volume_uuid: The volume to modify.
+        :param str new_volume_uuid: The new volume uuid to use.
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+        if new_volume_uuid in self._volumes:
+            raise LinstorVolumeManagerError(
+                'Volume `{}` already exists'.format(new_volume_uuid),
+                LinstorVolumeManagerError.ERR_VOLUME_EXISTS
+            )
+
+        volume_properties = self._get_volume_properties(volume_uuid)
+        if volume_properties.get(self.PROP_UPDATING_UUID_SRC):
+            raise LinstorVolumeManagerError(
+                'Cannot update volume uuid {}: invalid state'
+                .format(volume_uuid)
+            )
+
+        try:
+            # 1. Mark new volume properties with PROP_UPDATING_UUID_SRC.
+            # If we crash after that, the new properties can be removed
+            # properly.
+            new_volume_properties = self._get_volume_properties(
+                new_volume_uuid
+            )
+            if list(new_volume_properties.items()):
+                raise LinstorVolumeManagerError(
+                    'Cannot update volume uuid {} to {}: '
+                    .format(volume_uuid, new_volume_uuid) +
+                    'this last one is not empty'
+                )
+
+            new_volume_properties[self.PROP_NOT_EXISTS] = self.STATE_NOT_EXISTS
+            new_volume_properties[self.PROP_UPDATING_UUID_SRC] = volume_uuid
+
+            # 2. Copy the properties.
+            for property in [self.PROP_METADATA, self.PROP_VOLUME_NAME]:
+                new_volume_properties[property] = \
+                    volume_properties.get(property)
+
+            # 3. Ok!
+            new_volume_properties[self.PROP_NOT_EXISTS] = self.STATE_EXISTS
+        except Exception as e:
+            try:
+                new_volume_properties.clear()
+            except Exception as e:
+                self._logger(
+                    'Failed to clear new volume properties: {} (ignoring...)'
+                    .format(e)
+                )
+            raise LinstorVolumeManagerError(
+                'Failed to copy volume properties: {}'.format(e)
+            )
+
+        try:
+            # 4. After this point, it's ok we can remove the
+            # PROP_UPDATING_UUID_SRC property and clear the src properties
+            # without problems.
+            volume_properties.clear()
+            new_volume_properties.pop(self.PROP_UPDATING_UUID_SRC)
+        except Exception as e:
+            raise LinstorVolumeManagerError(
+                'Failed to clear volume properties '
+                'after volume uuid update: {}'.format(e)
+            )
+
+        self._volumes.remove(volume_uuid)
+        self._volumes.add(new_volume_uuid)
+
+    def update_volume_name(self, volume_uuid, volume_name):
+        """
+        Change the volume name of a volume.
+        :param str volume_uuid: The volume to modify.
+        :param str volume_name: The volume_name to use.
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+        if not volume_name.startswith(self.PREFIX_VOLUME):
+            raise LinstorVolumeManagerError(
+                'Volume name `{}` must be start with `{}`'
+                .format(volume_name, self.PREFIX_VOLUME)
+            )
+
+        if volume_name not in self._fetch_resource_names():
+            raise LinstorVolumeManagerError(
+                'Volume `{}` doesn\'t exist'.format(volume_name)
+            )
+
+        volume_properties = self._get_volume_properties(volume_uuid)
+        volume_properties[self.PROP_VOLUME_NAME] = volume_name
+
+    def get_usage_states(self, volume_uuid):
+        """
+        Check if a volume is currently used.
+        :param str volume_uuid: The volume uuid to check.
+        :return: A dictionnary that contains states.
+        :rtype: dict(str, bool or None)
+        """
+
+        states = {}
+
+        volume_name = self.get_volume_name(volume_uuid)
+        for resource_state in self._linstor.resource_list_raise(
+            filter_by_resources=[volume_name]
+        ).resource_states:
+            states[resource_state.node_name] = resource_state.in_use
+
+        return states
+
+    def get_volume_metadata(self, volume_uuid):
+        """
+        Get the metadata of a volume.
+        :return: Dictionary that contains metadata.
+        :rtype: dict
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+        volume_properties = self._get_volume_properties(volume_uuid)
+        metadata = volume_properties.get(self.PROP_METADATA)
+        if metadata:
+            metadata = json.loads(metadata)
+            if isinstance(metadata, dict):
+                return metadata
+            raise LinstorVolumeManagerError(
+                'Expected dictionary in volume metadata: {}'
+                .format(volume_uuid)
+            )
+        return {}
+
+    def set_volume_metadata(self, volume_uuid, metadata):
+        """
+        Set the metadata of a volume.
+        :param dict metadata: Dictionary that contains metadata.
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+
+        assert isinstance(metadata, dict)
+        volume_properties = self._get_volume_properties(volume_uuid)
+        volume_properties[self.PROP_METADATA] = json.dumps(metadata)
+
+    def update_volume_metadata(self, volume_uuid, metadata):
+        """
+        Update the metadata of a volume. It modify only the given keys.
+        It doesn't remove unreferenced key instead of set_volume_metadata.
+        :param dict metadata: Dictionary that contains metadata.
+        """
+
+        self._ensure_volume_exists(volume_uuid)
+
+        assert isinstance(metadata, dict)
+        volume_properties = self._get_volume_properties(volume_uuid)
+
+        current_metadata = json.loads(
+            volume_properties.get(self.PROP_METADATA, '{}')
+        )
+        if not isinstance(metadata, dict):
+            raise LinstorVolumeManagerError(
+                'Expected dictionary in volume metadata: {}'
+                .format(volume_uuid)
+            )
+
+        for key, value in metadata.items():
+            current_metadata[key] = value
+        volume_properties[self.PROP_METADATA] = json.dumps(current_metadata)
+
+    def shallow_clone_volume(self, volume_uuid, clone_uuid, persistent=True):
+        """
+        Clone a volume. Do not copy the data, this method creates a new volume
+        with the same size. It tries to create the volume on the same host
+        than volume source.
+        :param str volume_uuid: The volume to clone.
+        :param str clone_uuid: The cloned volume.
+        :param bool persistent: If false the volume will be unavailable
+        on the next constructor call LinstorSR(...).
+        :return: The current device path of the cloned volume.
+        :rtype: str
+        """
+
+        volume_name = self.get_volume_name(volume_uuid)
+
+        # 1. Find ideal nodes + size to use.
+        ideal_node_names, size = self._get_volume_node_names_and_size(
+            volume_name
+        )
+        if size <= 0:
+            raise LinstorVolumeManagerError(
+                'Invalid size of {} for volume `{}`'.format(size, volume_name)
+            )
+
+        # 2. Find the node(s) with the maximum space.
+        candidates = self._find_best_size_candidates()
+        if not candidates:
+            raise LinstorVolumeManagerError(
+                'Unable to shallow clone volume `{}`, no free space found.'
+            )
+
+        # 3. Compute node names and search if we can try to clone
+        # on the same nodes than volume.
+        def find_best_nodes():
+            for candidate in candidates:
+                for node_name in candidate.node_names:
+                    if node_name in ideal_node_names:
+                        return candidate.node_names
+
+        node_names = find_best_nodes()
+        if not node_names:
+            node_names = candidates[0].node_names
+
+        if len(node_names) < self._redundancy:
+            raise LinstorVolumeManagerError(
+                'Unable to shallow clone volume `{}`, '.format(volume_uuid) +
+                '{} are required to clone, found: {}'.format(
+                    self._redundancy, len(node_names)
+                )
+            )
+
+        # 4. Compute resources to create.
+        clone_volume_name = self.build_volume_name(util.gen_uuid())
+        diskless_node_names = self._get_node_names()
+        resources = []
+        for node_name in node_names:
+            diskless_node_names.remove(node_name)
+            resources.append(linstor.ResourceData(
+                node_name=node_name,
+                rsc_name=clone_volume_name,
+                storage_pool=self._group_name
+            ))
+        for node_name in diskless_node_names:
+            resources.append(linstor.ResourceData(
+                node_name=node_name,
+                rsc_name=clone_volume_name,
+                diskless=True
+            ))
+
+        # 5. Clone!
+        volume_properties = self._create_volume_with_properties(
+            clone_uuid, clone_volume_name, size, place_resources=False
+        )
+
+        try:
+            result = self._linstor.resource_create(resources)
+            error_str = self._get_error_str(result)
+            if error_str:
+                raise LinstorVolumeManagerError(
+                    'Could not create cloned volume `{}` of `{}` from SR `{}`:'
+                    ' {}'.format(
+                        clone_uuid, volume_uuid, self._group_name, error_str
+                    )
+                )
+
+            device_path = self._find_device_path(clone_uuid, clone_volume_name)
+            if persistent:
+                volume_properties[self.PROP_NOT_EXISTS] = self.STATE_EXISTS
+            self._volumes.add(clone_uuid)
+            return device_path
+        except Exception as e:
+            self._logger(
+                'Failed to shallow clone volume {}: {}'
+                .format(self._group_name, e)
+            )
+            try:
+                self._destroy_volume(clone_uuid, volume_properties)
+            except Exception as e:
+                self._logger(
+                    'Unable to destroy volume {} after shallow clone fail: {}'
+                    .format(clone_uuid, e)
+                )
+            raise
+
+    def remove_resourceless_volumes(self):
+        """
+        Remove all volumes without valid or non-empty name
+        (i.e. without LINSTOR resource). It's different than
+        LinstorVolumeManager constructor that takes a `repair` param that
+        removes volumes with `PROP_NOT_EXISTS` to 1.
+        """
+
+        resource_names = self._fetch_resource_names()
+        for volume_uuid, volume_name in self.volumes_with_name.items():
+            if not volume_name or volume_name not in resource_names:
+                self.destroy_volume(volume_uuid)
+
+    def destroy(self, force=False):
+        """
+        Destroy this SR. Object should not be used after that.
+        :param bool force: Try to destroy volumes before if true.
+        """
+
+        if (force):
+            for volume_uuid in self._volumes:
+                self.destroy_volume(volume_uuid)
+
+        # TODO: Throw exceptions in the helpers below if necessary.
+        # TODO: What's the required action if it exists remaining volumes?
+
+        self._destroy_resource_group(self._linstor, self._group_name)
+
+        pools = self._linstor.storage_pool_list_raise(
+            filter_by_stor_pools=[self._group_name]
+        ).storage_pools
+        for pool in pools:
+            self._destroy_storage_pool(
+                self._linstor, pool.name, pool.node_name
+            )
+
+    def find_up_to_date_diskfull_nodes(self, volume_uuid):
+        """
+        Find all nodes that contain a specific volume using diskfull disks.
+        The disk must be up to data to be used.
+        :param str volume_uuid: The volume to use.
+        :return: The available nodes.
+        :rtype: set(str)
+        """
+
+        volume_name = self.get_volume_name(volume_uuid)
+
+        node_names = set()
+        resource_list = self._linstor.resource_list_raise(
+            filter_by_resources=[volume_name]
+        )
+        for resource_state in resource_list.resource_states:
+            volume_state = resource_state.volume_states[0]
+            if volume_state.disk_state == 'UpToDate':
+                node_names.add(resource_state.node_name)
+
+        return node_names
+
+    @classmethod
+    def create_sr(
+        cls, uri, group_name, node_names, redundancy,
+        thin_provisioning=False,
+        logger=default_logger.__func__
+    ):
+        """
+        Create a new SR on the given nodes.
+        :param str uri: URI to communicate with the LINSTOR controller.
+        :param str group_name: The SR group_name to use.
+        :param list[str] node_names: String list of nodes.
+        :param int redundancy: How many copy of volumes should we store?
+        :param function logger: Function to log messages.
+        :return: A new LinstorSr instance.
+        :rtype: LinstorSr
+        """
+
+        # 1. Check if SR already exists.
+        lin = cls._create_linstor_instance(uri)
+        driver_pool_name = group_name
+        group_name = cls._build_group_name(group_name)
+        pools = lin.storage_pool_list_raise(filter_by_stor_pools=[group_name])
+
+        # TODO: Maybe if the SR already exists and if the nodes are the same,
+        # we can try to use it directly.
+        pools = pools.storage_pools
+        if pools:
+            existing_node_names = map(lambda pool: pool.node_name, pools)
+            raise LinstorVolumeManagerError(
+                'Unable to create SR `{}`. It already exists on node(s): {}'
+                .format(group_name, existing_node_names)
+            )
+
+        if thin_provisioning:
+            driver_pool_parts = driver_pool_name.split('/')
+            if not len(driver_pool_parts) == 2:
+                raise LinstorVolumeManagerError(
+                    'Invalid group name using thin provisioning. '
+                    'Expected format: \'VG/LV`\''
+                )
+
+        # 2. Create storage pool on each node + resource group.
+        i = 0
+        try:
+            # 2.a. Create storage pools.
+            while i < len(node_names):
+                node_name = node_names[i]
+
+                result = lin.storage_pool_create(
+                    node_name=node_name,
+                    storage_pool_name=group_name,
+                    storage_driver='LVM_THIN' if thin_provisioning else 'LVM',
+                    driver_pool_name=driver_pool_name
+                )
+
+                error_str = cls._get_error_str(result)
+                if error_str:
+                    raise LinstorVolumeManagerError(
+                        'Could not create SP `{}` on node `{}`: {}'.format(
+                            group_name,
+                            node_name,
+                            error_str
+                        )
+                    )
+                i += 1
+
+            # 2.b. Create resource group.
+            result = lin.resource_group_create(
+                name=group_name,
+                place_count=redundancy,
+                storage_pool=group_name,
+                diskless_on_remaining=True
+            )
+            error_str = cls._get_error_str(result)
+            if error_str:
+                raise LinstorVolumeManagerError(
+                    'Could not create RG `{}`: {}'.format(
+                        group_name, error_str
+                    )
+                )
+
+            # 2.c. Create volume group.
+            result = lin.volume_group_create(group_name)
+            error_str = cls._get_error_str(result)
+            if error_str:
+                raise LinstorVolumeManagerError(
+                    'Could not create VG `{}`: {}'.format(
+                        group_name, error_str
+                    )
+                )
+
+        # 3. Remove storage pools/resource/volume group in the case of errors.
+        except Exception as e:
+            try:
+                cls._destroy_resource_group(lin, group_name)
+            except Exception:
+                pass
+            j = 0
+            i = min(i, len(node_names) - 1)
+            while j <= i:
+                try:
+                    cls._destroy_storage_pool(lin, group_name, node_names[j])
+                except Exception:
+                    pass
+                j += 1
+            raise e
+
+        # 4. Return new instance.
+        instance = cls.__new__(cls)
+        instance._uri = uri
+        instance._linstor = lin
+        instance._logger = logger
+        instance._redundancy = redundancy
+        instance._group_name = group_name
+        instance._volumes = set()
+        return instance
+
+    @classmethod
+    def build_device_path(cls, volume_name):
+        """
+        Build a device path given a volume name.
+        :param str volume_name: The volume name to use.
+        :return: A valid or not device path.
+        :rtype: str
+        """
+
+        return '{}{}/0'.format(cls.DEV_ROOT_PATH, volume_name)
+
+    @classmethod
+    def build_volume_name(cls, base_name):
+        """
+        Build a volume name given a base name (i.e. a UUID).
+        :param str volume_name: The volume name to use.
+        :return: A valid or not device path.
+        :rtype: str
+        """
+        return '{}{}'.format(cls.PREFIX_VOLUME, base_name)
+
+    @classmethod
+    def round_up_volume_size(cls, volume_size):
+        """
+        Align volume size on higher multiple of BLOCK_SIZE.
+        :param int volume_size: The volume size to align.
+        :return: An aligned volume size.
+        :rtype: int
+        """
+        return round_up(volume_size, cls.BLOCK_SIZE)
+
+    @classmethod
+    def round_down_volume_size(cls, volume_size):
+        """
+        Align volume size on lower multiple of BLOCK_SIZE.
+        :param int volume_size: The volume size to align.
+        :return: An aligned volume size.
+        :rtype: int
+        """
+        return round_down(volume_size, cls.BLOCK_SIZE)
+
+    # --------------------------------------------------------------------------
+    # Private helpers.
+    # --------------------------------------------------------------------------
+
+    def _ensure_volume_exists(self, volume_uuid):
+        if volume_uuid not in self._volumes:
+            raise LinstorVolumeManagerError(
+                'volume `{}` doesn\'t exist'.format(volume_uuid),
+                LinstorVolumeManagerError.ERR_VOLUME_NOT_EXISTS
+            )
+
+    def _find_best_size_candidates(self):
+        result = self._linstor.resource_group_qmvs(self._group_name)
+        error_str = self._get_error_str(result)
+        if error_str:
+            raise LinstorVolumeManagerError(
+                'Failed to get max volume size allowed of SR `{}`: {}'.format(
+                    self._group_name,
+                    error_str
+                )
+            )
+        return result[0].candidates
+
+    def _fetch_resource_names(self):
+        resource_names = set()
+        dfns = self._linstor.resource_dfn_list_raise().resource_definitions
+        for dfn in dfns:
+            if dfn.resource_group_name == self._group_name and \
+                    linstor.consts.FLAG_DELETE not in dfn.flags:
+                resource_names.add(dfn.name)
+        return resource_names
+
+    def _get_volumes_info(self, filter=None):
+        all_volume_info = {}
+        resources = self._linstor.resource_list_raise(
+            filter_by_resources=filter
+        )
+        for resource in resources.resources:
+            if resource.name not in all_volume_info:
+                current = all_volume_info[resource.name] = self.VolumeInfo(
+                    resource.name
+                )
+            else:
+                current = all_volume_info[resource.name]
+
+            for volume in resource.volumes:
+                # We ignore diskless pools of the form "DfltDisklessStorPool".
+                if volume.storage_pool_name == self._group_name:
+                    if volume.allocated_size < 0:
+                        raise LinstorVolumeManagerError(
+                           'Failed to get allocated size of `{}` on `{}`'
+                           .format(resource.name, volume.storage_pool_name)
+                        )
+                    current.physical_size += volume.allocated_size
+
+                    if volume.usable_size < 0:
+                        raise LinstorVolumeManagerError(
+                           'Failed to get usable size of `{}` on `{}`'
+                           .format(resource.name, volume.storage_pool_name)
+                        )
+                    virtual_size = volume.usable_size
+
+                    current.virtual_size = current.virtual_size and \
+                        min(current.virtual_size, virtual_size) or virtual_size
+
+        for current in all_volume_info.values():
+            current.physical_size *= 1024
+            current.virtual_size *= 1024
+
+        return all_volume_info
+
+    def _get_volume_node_names_and_size(self, volume_name):
+        node_names = set()
+        size = -1
+        for resource in self._linstor.resource_list_raise(
+            filter_by_resources=[volume_name]
+        ).resources:
+            for volume in resource.volumes:
+                # We ignore diskless pools of the form "DfltDisklessStorPool".
+                if volume.storage_pool_name == self._group_name:
+                    node_names.add(resource.node_name)
+
+                    current_size = volume.usable_size
+                    if current_size < 0:
+                        raise LinstorVolumeManagerError(
+                           'Failed to get usable size of `{}` on `{}`'
+                           .format(resource.name, volume.storage_pool_name)
+                        )
+
+                    if size < 0:
+                        size = current_size
+                    else:
+                        size = min(size, current_size)
+
+        return (node_names, size * 1024)
+
+    def _compute_size(self, attr):
+        pools = self._linstor.storage_pool_list_raise(
+            filter_by_stor_pools=[self._group_name]
+        ).storage_pools
+
+        capacity = 0
+        for pool in pools:
+            space = pool.free_space
+            if space:
+                size = getattr(space, attr)
+                if size < 0:
+                    raise LinstorVolumeManagerError(
+                        'Failed to get pool {} attr of `{}`'
+                        .format(attr, pool.node_name)
+                    )
+                capacity += size
+        return capacity * 1024
+
+    def _get_node_names(self):
+        node_names = set()
+        pools = self._linstor.storage_pool_list_raise(
+            filter_by_stor_pools=[self._group_name]
+        ).storage_pools
+        for pool in pools:
+            node_names.add(pool.node_name)
+        return node_names
+
+    def _check_volume_creation_errors(self, result, volume_uuid):
+        errors = self._filter_errors(result)
+        if self._check_errors(errors, [
+            linstor.consts.FAIL_EXISTS_RSC, linstor.consts.FAIL_EXISTS_RSC_DFN
+        ]):
+            raise LinstorVolumeManagerError(
+                'Failed to create volume `{}` from SR `{}`, it already exists'
+                .format(volume_uuid, self._group_name),
+                LinstorVolumeManagerError.ERR_VOLUME_EXISTS
+            )
+
+        if errors:
+            raise LinstorVolumeManagerError(
+                'Failed to create volume `{}` from SR `{}`: {}'.format(
+                    volume_uuid,
+                    self._group_name,
+                    self._get_error_str(errors)
+                )
+            )
+
+    def _create_volume(self, volume_uuid, volume_name, size, place_resources):
+        size = self.round_up_volume_size(size)
+
+        self._check_volume_creation_errors(self._linstor.resource_group_spawn(
+            rsc_grp_name=self._group_name,
+            rsc_dfn_name=volume_name,
+            vlm_sizes=['{}B'.format(size)],
+            definitions_only=not place_resources
+        ), volume_uuid)
+
+    def _create_volume_with_properties(
+        self, volume_uuid, volume_name, size, place_resources
+    ):
+        if self.check_volume_exists(volume_uuid):
+            raise LinstorVolumeManagerError(
+                'Could not create volume `{}` from SR `{}`, it already exists'
+                .format(volume_uuid, self._group_name) + ' in properties',
+                LinstorVolumeManagerError.ERR_VOLUME_EXISTS
+            )
+
+        if volume_name in self._fetch_resource_names():
+            raise LinstorVolumeManagerError(
+                'Could not create volume `{}` from SR `{}`, '.format(
+                    volume_uuid, self._group_name
+                ) + 'resource of the same name already exists in LINSTOR'
+            )
+
+        # I am paranoid.
+        volume_properties = self._get_volume_properties(volume_uuid)
+        if (volume_properties.get(self.PROP_NOT_EXISTS) is not None):
+            raise LinstorVolumeManagerError(
+                'Could not create volume `{}`, '.format(volume_uuid) +
+                'properties already exist'
+            )
+
+        try:
+            volume_properties[self.PROP_NOT_EXISTS] = self.STATE_CREATING
+            volume_properties[self.PROP_VOLUME_NAME] = volume_name
+
+            self._create_volume(
+                volume_uuid, volume_name, size, place_resources
+            )
+
+            return volume_properties
+        except LinstorVolumeManagerError as e:
+            # Do not destroy existing resource!
+            # In theory we can't get this error because we check this event
+            # before the `self._create_volume` case.
+            # It can only happen if the same volume uuid is used in the same
+            # call in another host.
+            if e.code == LinstorVolumeManagerError.ERR_VOLUME_EXISTS:
+                raise
+            self._force_destroy_volume(volume_uuid, volume_properties)
+            raise
+        except Exception:
+            self._force_destroy_volume(volume_uuid, volume_properties)
+            raise
+
+    def _find_device_path(self, volume_uuid, volume_name):
+        current_device_path = self._request_device_path(
+            volume_uuid, volume_name, activate=True
+        )
+
+        # We use realpath here to get the /dev/drbd<id> path instead of
+        # /dev/drbd/by-res/<resource_name>.
+        expected_device_path = self.build_device_path(volume_name)
+        util.wait_for_path(expected_device_path, 5)
+
+        device_realpath = os.path.realpath(expected_device_path)
+        if current_device_path != device_realpath:
+            raise LinstorVolumeManagerError(
+                'Invalid path, current={}, expected={} (realpath={})'
+                .format(
+                    current_device_path,
+                    expected_device_path,
+                    device_realpath
+                )
+            )
+        return expected_device_path
+
+    def _request_device_path(self, volume_uuid, volume_name, activate=False):
+        node_name = socket.gethostname()
+        resources = self._linstor.resource_list(
+            filter_by_nodes=[node_name],
+            filter_by_resources=[volume_name]
+        )
+
+        if not resources or not resources[0]:
+            raise LinstorVolumeManagerError(
+                'No response list for dev path of `{}`'.format(volume_uuid)
+            )
+        if isinstance(resources[0], linstor.responses.ResourceResponse):
+            if not resources[0].resources:
+                if activate:
+                    self._activate_device_path(node_name, volume_name)
+                    return self._request_device_path(volume_uuid, volume_name)
+                raise LinstorVolumeManagerError(
+                    'Empty dev path for `{}`, but definition "seems" to exist'
+                    .format(volume_uuid)
+                )
+            # Contains a path of the /dev/drbd<id> form.
+            return resources[0].resources[0].volumes[0].device_path
+
+        raise LinstorVolumeManagerError(
+            'Unable to get volume dev path `{}`: {}'.format(
+                volume_uuid, str(resources[0])
+            )
+        )
+
+    def _activate_device_path(self, node_name, volume_name):
+        result = self._linstor.resource_create([
+            linstor.ResourceData(node_name, volume_name, diskless=True)
+        ])
+        if linstor.Linstor.all_api_responses_no_error(result):
+            return
+        errors = linstor.Linstor.filter_api_call_response_errors(result)
+        if len(errors) == 1 and errors[0].is_error(
+            linstor.consts.FAIL_EXISTS_RSC
+        ):
+            return
+
+        raise LinstorVolumeManagerError(
+            'Unable to activate device path of `{}` on node `{}`: {}'
+            .format(volume_name, node_name, ', '.join(
+                [str(x) for x in result]))
+        )
+
+    def _destroy_resource(self, resource_name):
+        result = self._linstor.resource_dfn_delete(resource_name)
+        error_str = self._get_error_str(result)
+        if error_str:
+            raise LinstorVolumeManagerError(
+                'Could not destroy resource `{}` from SR `{}`: {}'
+                .format(resource_name, self._group_name, error_str)
+            )
+
+    def _destroy_volume(self, volume_uuid, volume_properties):
+        assert volume_properties.namespace == \
+            self._build_volume_namespace(volume_uuid)
+
+        try:
+            volume_name = volume_properties.get(self.PROP_VOLUME_NAME)
+            if volume_name in self._fetch_resource_names():
+                self._destroy_resource(volume_name)
+
+            # Assume this call is atomic.
+            volume_properties.clear()
+        except Exception as e:
+            raise LinstorVolumeManagerError(
+                'Cannot destroy volume `{}`: {}'.format(volume_uuid, e)
+            )
+
+    def _force_destroy_volume(self, volume_uuid, volume_properties):
+        try:
+            self._destroy_volume(volume_uuid, volume_properties)
+        except Exception as e:
+            self._logger('Ignore fail: {}'.format(e))
+
+    def _build_volumes(self, repair):
+        properties = linstor.KV(
+            self._get_store_name(),
+            uri=self._uri,
+            namespace=self._build_volume_namespace()
+        )
+
+        resource_names = self._fetch_resource_names()
+
+        self._volumes = set()
+
+        updating_uuid_volumes = self._get_volumes_by_property(
+            self.REG_UPDATING_UUID_SRC, ignore_inexisting_volumes=False
+        )
+        if updating_uuid_volumes and not repair:
+            raise LinstorVolumeManagerError(
+                'Cannot build LINSTOR volume list: '
+                'It exists invalid "updating uuid volumes", repair is required'
+            )
+
+        existing_volumes = self._get_volumes_by_property(
+            self.REG_NOT_EXISTS, ignore_inexisting_volumes=False
+        )
+        for volume_uuid, not_exists in existing_volumes.items():
+            properties.namespace = self._build_volume_namespace(
+                volume_uuid
+            )
+
+            src_uuid = properties.get(self.PROP_UPDATING_UUID_SRC)
+            if src_uuid:
+                continue
+
+            # Insert volume in list if the volume exists. Or if the volume
+            # is being created and a slave wants to use it (repair = False).
+            #
+            # If we are on the master and if repair is True and state is
+            # Creating, it's probably a bug or crash: the creation process has
+            # been stopped.
+            if not_exists == self.STATE_EXISTS or (
+                not repair and not_exists == self.STATE_CREATING
+            ):
+                self._volumes.add(volume_uuid)
+                continue
+
+            if not repair:
+                continue
+
+            # Remove bad volume.
+            try:
+                volume_name = properties.get(self.PROP_VOLUME_NAME)
+
+                # Little optimization, don't call `self._destroy_volume`,
+                # we already have resource name list.
+                if volume_name in resource_names:
+                    self._destroy_resource(volume_name)
+
+                # Assume this call is atomic.
+                properties.clear()
+            except Exception as e:
+                # Do not raise, we don't want to block user action.
+                self._logger(
+                    'Cannot clean volume {}: {}'.format(volume_uuid, e)
+                )
+
+            for dest_uuid, src_uuid in updating_uuid_volumes.items():
+                dest_properties = self._get_volume_properties(dest_uuid)
+                if int(dest_properties.get(self.PROP_NOT_EXISTS) or
+                        self.STATE_EXISTS):
+                    dest_properties.clear()
+                    continue
+
+                src_properties = self._get_volume_properties(src_uuid)
+                src_properties.clear()
+
+                dest_properties.pop(self.PROP_UPDATING_UUID_SRC)
+
+                if src_uuid in self._volumes:
+                    self._volumes.remove(src_uuid)
+                self._volumes.add(dest_uuid)
+
+    def _get_sr_properties(self):
+        return linstor.KV(
+            self._get_store_name(),
+            uri=self._uri,
+            namespace=self._build_sr_namespace()
+        )
+
+    def _get_volumes_by_property(
+        self, reg_prop, ignore_inexisting_volumes=True
+    ):
+        base_properties = linstor.KV(
+            self._get_store_name(),
+            uri=self._uri,
+            namespace=self._build_volume_namespace()
+        )
+
+        volume_properties = {}
+        for volume_uuid in self._volumes:
+            volume_properties[volume_uuid] = ''
+
+        for key, value in base_properties.items():
+            res = reg_prop.match(key)
+            if res:
+                volume_uuid = res.groups()[0]
+                if not ignore_inexisting_volumes or \
+                        volume_uuid in self._volumes:
+                    volume_properties[volume_uuid] = value
+
+        return volume_properties
+
+    def _get_volume_properties(self, volume_uuid):
+        return linstor.KV(
+            self._get_store_name(),
+            uri=self._uri,
+            namespace=self._build_volume_namespace(volume_uuid)
+        )
+
+    def _get_store_name(self):
+        return 'xcp-sr-{}'.format(self._group_name)
+
+    @classmethod
+    def _build_sr_namespace(cls):
+        return '/{}/'.format(cls.NAMESPACE_SR)
+
+    @classmethod
+    def _build_volume_namespace(cls, volume_uuid=None):
+        # Return a path to all volumes if `volume_uuid` is not given.
+        if volume_uuid is None:
+            return '/{}/'.format(cls.NAMESPACE_VOLUME)
+        return '/{}/{}/'.format(cls.NAMESPACE_VOLUME, volume_uuid)
+
+    @classmethod
+    def _get_error_str(cls, result):
+        return ', '.join([
+            err.message for err in cls._filter_errors(result)
+        ])
+
+    @classmethod
+    def _create_linstor_instance(cls, uri):
+        instance = linstor.Linstor(uri, keep_alive=True)
+        instance.connect()
+        return instance
+
+    @classmethod
+    def _destroy_storage_pool(cls, lin, group_name, node_name):
+        result = lin.storage_pool_delete(node_name, group_name)
+        error_str = cls._get_error_str(result)
+        if error_str:
+            raise LinstorVolumeManagerError(
+                'Failed to destroy SP `{}` on node `{}`: {}'.format(
+                    group_name,
+                    node_name,
+                    error_str
+                )
+            )
+
+    @classmethod
+    def _destroy_resource_group(cls, lin, group_name):
+        result = lin.resource_group_delete(group_name)
+        error_str = cls._get_error_str(result)
+        if error_str:
+            raise LinstorVolumeManagerError(
+                'Failed to destroy RG `{}`: {}'.format(group_name, error_str)
+            )
+
+    @classmethod
+    def _build_group_name(cls, base_name):
+        # If thin provisioning is used we have a path like this:
+        # `VG/LV`. "/" is not accepted by LINSTOR.
+        return '{}{}'.format(cls.PREFIX_SR, base_name.replace('/', '_'))
+
+    @staticmethod
+    def _filter_errors(result):
+        return [
+            err for err in result
+            if hasattr(err, 'is_error') and err.is_error()
+        ]
+
+    @staticmethod
+    def _check_errors(result, codes):
+        for err in result:
+            for code in codes:
+                if err.is_error(code):
+                    return True
+        return False

--- a/drivers/tapdisk-pause
+++ b/drivers/tapdisk-pause
@@ -29,6 +29,8 @@ import lvhdutil
 import vhdutil
 import lvmcache
 
+from linstorvolumemanager import LinstorVolumeManager
+
 TAPDEV_BACKPATH_PFX = "/dev/sm/backend"
 TAPDEV_PHYPATH_PFX = "/dev/sm/phy"
 
@@ -72,24 +74,6 @@ def _mkphylink(sr_uuid, vdi_uuid, path):
     cmd = ['ln', '-sf', path, sympath]
     util.pread2(cmd)
     return path
-
-def _pathRefresh():
-    # LVM rename check
-    realpath = os.path.realpath(self.phypath)
-    phypath = vdi_type = None
-    util.SMlog("Realpath: %s" % realpath)
-    if realpath.startswith("/dev/VG_XenStorage-") and \
-            not os.path.exists(realpath):
-        util.SMlog("Path inconsistent")
-        pfx = "/dev/VG_XenStorage-%s/" % self.sr_uuid
-        for ty in ["LV","VHD"]:
-            p = pfx + ty + "-" + self.vdi_uuid
-            util.SMlog("Testing path: %s" % p)
-            if os.path.exists(p):
-                _mkphylink(self.sr_uuid, self.vdi_uuid, p)
-                phypath = p
-                if ty == "LV": vdi_type = "aio"
-                else: vdi_type = "vhd"
 
 def tapPause(session, args):
     tap = Tapdisk(session, args)
@@ -148,7 +132,46 @@ class Tapdisk:
                     self.realpath = p
                     if ty == "LV": self.vdi_type = "aio"
                     else: self.vdi_type = "vhd"
-        
+        elif realpath.startswith('/dev/drbd/by-res/xcp-volume-'):
+            # We must always recreate the symlink to ensure we have
+            # the right info. Why? Because if the volume UUID is changed in
+            # LINSTOR the symlink is not directly updated. When live leaf
+            # coalesce is executed we have these steps:
+            # "A" -> "OLD_A"
+            # "B" -> "A"
+            # Without symlink update the previous "A" path is reused instead of
+            # "B" path. Note: "A", "B" and "OLD_A" are UUIDs.
+            session = self.session
+
+            linstor_uri = 'linstor://{}'.format(
+                util.get_master_rec(session)['address']
+            )
+
+            host_ref = util.get_this_host_ref(session)
+            sr_ref = session.xenapi.SR.get_by_uuid(self.sr_uuid)
+
+            pbd = util.find_my_pbd(session, host_ref, sr_ref)
+            if pbd is None:
+                raise util.SMException('Failed to find PBD')
+
+            dconf = session.xenapi.PBD.get_device_config(pbd)
+            group_name = dconf['group-name']
+
+            device_path = LinstorVolumeManager(
+                linstor_uri,
+                group_name,
+                logger=util.SMlog
+            ).get_device_path(self.vdi_uuid)
+
+            if realpath != device_path:
+                util.SMlog(
+                    'Update LINSTOR PhyLink (previous={}, current={})'
+                    .format(realpath, device_path)
+                )
+                os.unlink(self.phypath)
+                _mkphylink(self.sr_uuid, self.vdi_uuid, device_path)
+            self.realpath = device_path
+
     @locking("VDIUnavailable")
     def Pause(self):
         util.SMlog("Pause for %s" % self.vdi_uuid)

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -651,10 +651,18 @@ def get_this_host():
     f.close()
     return uuid
 
-def is_master(session):
+
+def get_master_ref(session):
     pools = session.xenapi.pool.get_all()
-    master = session.xenapi.pool.get_master(pools[0])
-    return get_this_host_ref(session) == master
+    return session.xenapi.pool.get_master(pools[0])
+
+
+def get_master_rec(session):
+    return session.xenapi.host.get_record(get_master_ref(session))
+
+
+def is_master(session):
+    return get_this_host_ref(session) == get_master_ref(session)
 
 # XXX: this function doesn't do what it claims to do
 def get_localhost_uuid(session):


### PR DESCRIPTION
Some important points:

- linstor.KV must use an identifier name that starts with a letter (so it uses a "sr-" prefix).

- Encrypted VDI are supported with key_hash attribute (not tested, experimental).

- When a new LINSTOR volume is created on a host (via snapshot or create), the remaining diskless
devices are not necessarily created on other hosts. So if a resource definition exists without
local device path, we ask it to LINSTOR. Wait 5s for symlink creation when a new volume
is created => 5s is is purely arbitrary, but this guarantees that we do not try to access the
volume if the symlink has not yet been created by the udev rule.

- Can change the provisioning using the device config 'provisioning' param.

- We can only increase volume size (See: https://github.com/LINBIT/linstor-server/issues/66),
it would be great if we could shrink volumes to limit the space used by the snapshots.

- Inflate/Deflate can only be executed on the master host, a linstor-manager plugin is present
to do this from slaves. The same plugin is used to open LINSTOR ports + start controller.

- Use a `total_allocated_volume_size` method to have a good idea of the reserved memory
Why? Because `physical_free_size` is computed using the LVM used size, in the case of thick provisioning it's ok,
but when thin provisioning is choosen LVM returns only the allocated size using the used block count. So this method
solves this problem, it takes the fixed virtual volume size of each node to compute the required size to store the
volume data.

- Call vhd-util on remote hosts using the linstor-manager when necessary, i.e. vhd-util is called to get vhd info,
the DRBD device can be in use (and unusable by external processes), so we must use the local LVM device that
contains the DRBD data or a remote disk if the DRBD device is diskless.

- If a DRBD device is in use when vhdutil.getVHDInfo is called, we must have no
errors. So a LinstorVhdUtil wrapper is now used to bypass DRBD layer when
VDIs are loaded.

- Refresh PhyLink when unpause in called on DRBD devices:
We must always recreate the symlink to ensure we have
the right info. Why? Because if the volume UUID is changed in
LINSTOR the symlink is not directly updated. When live leaf
coalesce is executed we have these steps:
"A" -> "OLD_A"
"B" -> "A"
Without symlink update the previous "A" path is reused instead of
"B" path. Note: "A", "B" and "OLD_A" are UUIDs.