### PR TITLE
Remove SR_CACHING capability for many SR types

### DIFF
--- a/drivers/CephFSSR.py
+++ b/drivers/CephFSSR.py
@@ -38,7 +38,7 @@ import vhdutil
 import xs_errors
 from lock import Lock
 
-CAPABILITIES = ["SR_PROBE", "SR_UPDATE", "SR_CACHING",
+CAPABILITIES = ["SR_PROBE", "SR_UPDATE",
                 "VDI_CREATE", "VDI_DELETE", "VDI_ATTACH", "VDI_DETACH",
                 "VDI_UPDATE", "VDI_CLONE", "VDI_SNAPSHOT", "VDI_RESIZE", "VDI_MIRROR",
                 "VDI_GENERATE_CONFIG",

--- a/drivers/GlusterFSSR.py
+++ b/drivers/GlusterFSSR.py
@@ -35,7 +35,7 @@ import vhdutil
 import xs_errors
 from lock import Lock
 
-CAPABILITIES = ["SR_PROBE", "SR_UPDATE", "SR_CACHING",
+CAPABILITIES = ["SR_PROBE", "SR_UPDATE",
                 "VDI_CREATE", "VDI_DELETE", "VDI_ATTACH", "VDI_DETACH",
                 "VDI_UPDATE", "VDI_CLONE", "VDI_SNAPSHOT", "VDI_RESIZE", "VDI_MIRROR",
                 "VDI_GENERATE_CONFIG",

--- a/drivers/MooseFSSR.py
+++ b/drivers/MooseFSSR.py
@@ -39,7 +39,7 @@ import vhdutil
 import xs_errors
 from lock import Lock
 
-CAPABILITIES = ["SR_PROBE", "SR_UPDATE", "SR_CACHING",
+CAPABILITIES = ["SR_PROBE", "SR_UPDATE",
                 "VDI_CREATE", "VDI_DELETE", "VDI_ATTACH", "VDI_DETACH",
                 "VDI_UPDATE", "VDI_CLONE", "VDI_SNAPSHOT", "VDI_RESIZE", "VDI_MIRROR",
                 "VDI_GENERATE_CONFIG",


### PR DESCRIPTION
SR_CACHING offers the capacity to use IntelliCache, but this
feature is only available using NFS SR.

For more details, the implementation of `_setup_cache` in blktap2.py
uses only an instance of NFSFileVDI for the shared target.

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>