### PR TITLE
Fix is_open call for many drivers

### DIFF
--- a/drivers/on_slave.py
+++ b/drivers/on_slave.py
@@ -72,7 +72,15 @@ def multi(session, args):
 
 def _is_open(session, args):
     """Check if VDI <args["vdiUuid"]> is open by a tapdisk on this host"""
-    import SRCommand, SR, NFSSR, EXTSR, LVHDSR, blktap2
+    import SRCommand
+    import SR
+    import CephFSSR
+    import EXTSR
+    import GlusterFSSR
+    import MooseFSSR
+    import NFSSR
+    import ZFSSR
+    import blktap2
 
     util.SMlog("on-slave.is_open: %s" % args)
     vdiUuid = args["vdiUuid"]
@@ -86,7 +94,7 @@ def _is_open(session, args):
         srType = "lvhd"
     cmd = SRCommand.SRCommand(None)
     cmd.driver_info = {"capabilities": None}
-    cmd.dconf = {"server": None, "device": "/HACK"}
+    cmd.dconf = {"server": None, "device": "/HACK", "masterhost": None}
     cmd.params = {"command": None}
 
     driver = SR.driver(srType)


### PR DESCRIPTION
Ensure all shared drivers are imported in `_is_open` definition to register
them in the driver list. Otherwise this function always fails with a SRUnknownType exception.

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>