### PR TITLE
feat(linstor-manager): add new `healthCheck` function to monitor pool

### DIFF
--- a/drivers/linstor-manager
+++ b/drivers/linstor-manager
@@ -848,6 +848,119 @@ def get_drbd_openers(session, args):
         raise
 
 
+def health_check(session, args):
+    group_name = args['groupName']
+
+    result = {
+       'controller-uri': '',
+       'nodes': {},
+       'storage-pools': {},
+       'warnings': [],
+       'errors': []
+    }
+
+    def format_result():
+        return json.dumps(result)
+
+    # 1. Get controller.
+    try:
+        controller_uri = get_controller_uri()
+
+        result['controller-uri'] = controller_uri
+        try:
+            if controller_uri == 'linstor://localhost':
+                # Replace `localhost` with IP to give a better info for users.
+                result['controller-uri'] = 'linstor://' + util.get_this_host_address(session)
+        except Exception:
+            # Ignore error: can be a XAPI restart or something else.
+            pass
+
+        linstor = LinstorVolumeManager(
+            controller_uri,
+            group_name,
+            logger=util.SMlog
+        )
+    except Exception as e:
+        # Probably a network issue, or offline controller.
+        result['errors'].append('Cannot join SR: `{}`.'.format(e))
+        return format_result()
+
+    try:
+        # 2. Check node statuses.
+        nodes = linstor.get_nodes_info()
+        result['nodes'] = nodes
+        for node_name, status in nodes.items():
+            if status != 'ONLINE':
+                result['warnings'].append('Node `{}` is {}.'.format(node_name, status))
+
+        # 3. Check storage pool statuses.
+        storage_pools_per_node = linstor.get_storage_pools_info()
+        result['storage-pools'] = storage_pools_per_node
+        for node_name, storage_pools in storage_pools_per_node.items():
+            for storage_pool in storage_pools:
+                free_size = storage_pool['free-size']
+                capacity = storage_pool['capacity']
+                if free_size < 0 or capacity <= 0:
+                    result['errors'].append(
+                        'Cannot get free size and/or capacity of storage pool `{}`.'
+                        .format(storage_pool['uuid'])
+                    )
+                elif free_size > capacity:
+                    result['errors'].append(
+                        'Free size of storage pool `{}` is greater than capacity.'
+                        .format(storage_pool['uuid'])
+                    )
+                else:
+                    remaining_percent = free_size / float(capacity) * 100.0
+                    threshold = 10.0
+                    if remaining_percent < threshold:
+                        result['warnings'].append(
+                            'Remaining size of storage pool `{}` is below {}% of its capacity.'
+                            .format(storage_pool['uuid'], threshold)
+                        )
+
+        # 4. Check resource statuses.
+        all_resources = linstor.get_resources_info()
+        result['resources'] = all_resources
+
+        for resource_name, resource_by_node in all_resources.items():
+            for node_name, resource in resource_by_node.items():
+                for volume_index, volume in enumerate(resource['volumes']):
+                    disk_state = volume['disk-state']
+                    if disk_state in ['UpToDate', 'Created', 'Attached']:
+                        continue
+                    if disk_state == 'DUnknown':
+                        result['warnings'].append(
+                            'Unknown state for volume `{}` at index {} for resource `{}` on node `{}`'
+                            .format(volume['device-path'], volume_index, resource_name, node_name)
+                        )
+                        continue
+                    if disk_state in ['Inconsistent', 'Failed', 'To: Creating', 'To: Attachable', 'To: Attaching']:
+                        result['errors'].append(
+                            'Invalid state `{}` for volume `{}` at index {} for resource `{}` on node `{}`'
+                            .format(disk_state, volume['device-path'], volume_index, resource_name, node_name)
+                        )
+                        continue
+                    if disk_state == 'Diskless':
+                        if resource['diskful']:
+                            result['errors'].append(
+                                'Unintentional diskless state detected for volume `{}` at index {} for resource `{}` on node `{}`'
+                                .format(volume['device-path'], volume_index, resource_name, node_name)
+                            )
+                        elif resource['tie-breaker']:
+                            volume['disk-state'] = 'TieBreaker'
+                        continue
+                    result['warnings'].append(
+                        'Unhandled state `{}` for volume `{}` at index {} for resource `{}` on node `{}`'
+                        .format(disk_state, volume['device-path'], volume_index, resource_name, node_name)
+                    )
+
+    except Exception as e:
+        result['errors'].append('Unexpected error: `{}`'.format(e))
+
+    return format_result()
+
+
 if __name__ == '__main__':
     XenAPIPlugin.dispatch({
         'prepareSr': prepare_sr,
@@ -887,5 +1000,6 @@ if __name__ == '__main__':
         'listDrbdVolumes': list_drbd_volumes,
         'destroyDrbdVolume': destroy_drbd_volume,
         'destroyDrbdVolumes': destroy_drbd_volumes,
-        'getDrbdOpeners': get_drbd_openers
+        'getDrbdOpeners': get_drbd_openers,
+        'healthCheck': health_check
     })


### PR DESCRIPTION
Print a JSON output to monitor state of LINSTOR SRs:
  - Display nodes, storage pool and resources
  - Print human readable warns and errors

Usage example:

```
xe host-call-plugin host-uuid=c96ec4dd-28ac-4df4-b73c-4371bd202728 plugin=linstor-manager fn=healthCheck args:groupName=linstor_group
```

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>