### PR TITLE
fix for other-config: scheduler v2

### DIFF
--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -208,7 +208,7 @@ class SR(object):
     def block_setscheduler(self, dev):
         try:
             realdev = os.path.realpath(dev)
-            disk    = util.diskFromPartition(realdev)
+            disk    = util.diskFromPartition(realdev[5:])
 
             # the normal case: the sr default scheduler (typically noop),
             # potentially overridden by SR.other_config:scheduler
@@ -218,7 +218,8 @@ class SR(object):
                 sched = self.sched
 
             # special case: CFQ if the underlying disk holds dom0's file systems.
-            if disk in util.dom0_disks():
+            # NVMe doesn't support CFQ
+            if disk in util.dom0_disks() and not disk.startswith('nvme'):
                 sched = 'cfq'
 
             util.SMlog("Block scheduler: %s (%s) wants %s" % (dev, disk, sched))

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1026,6 +1026,10 @@ def diskFromPartition(partition):
     if True in [partition.startswith(x) for x in ['cciss', 'ida', 'rd']]:
         numlen += 1 # need to get rid of trailing 'p'
 
+    # is it a NVMe ? nvme0n1p33
+    if partition.startswith('nvme'):
+        numlen += 1 # need to get rid of trailing 'p'
+
     # is it a mapper path?
     if partition.startswith("mapper"):
         if re.search("p[0-9]*$",partition):


### PR DESCRIPTION
- fixed call diskFromPartition() from block_setscheduler: it requires path without /dev/
- diskFromPartition() should remove trailing "p" for NVMe drives too
- forced setup of CFQ scheduler skipped for NVMe drives, because it's unsupported

PS
My apologize for some disorder in previous version of this PR. Some unexpected troubles with gpg signature ((