### PR TITLE
Remove `_isvalidpathstring` calls

### DIFF
--- a/drivers/EXT4SR.py
+++ b/drivers/EXT4SR.py
@@ -62,10 +62,6 @@ class EXT4SR(FileSR.FileSR):
             raise xs_errors.XenError('ConfigDeviceMissing')
 
         self.root = self.dconf['device']
-        for dev in self.root.split(','):
-            if not self._isvalidpathstring(dev):
-                raise xs_errors.XenError('ConfigDeviceInvalid', \
-                      opterr='path is %s' % dev)
         self.path = os.path.join(SR.MOUNT_BASE, sr_uuid)
         self.vgname = EXT_PREFIX + sr_uuid
         self.remotepath = os.path.join("/dev",self.vgname,sr_uuid)

--- a/drivers/XFSSR.py
+++ b/drivers/XFSSR.py
@@ -71,10 +71,6 @@ class XFSSR(FileSR.FileSR):
             raise xs_errors.XenError('ConfigDeviceMissing')
 
         self.root = self.dconf['device']
-        for dev in self.root.split(','):
-            if not self._isvalidpathstring(dev):
-                raise xs_errors.XenError('ConfigDeviceInvalid', \
-                      opterr='path is %s' % dev)
         self.path = os.path.join(SR.MOUNT_BASE, sr_uuid)
         self.vgname = EXT_PREFIX + sr_uuid
         self.remotepath = os.path.join("/dev",self.vgname,sr_uuid)


### PR DESCRIPTION
Since CA-370696 upstream commit, `_isvalidpathstring` is no longer available. So the device path given to a SR at creation is checked using specific commands:
  - `vgcreate` for XFS SR.
  - Normally the same idea for EXT4 but the creation is deprecated, so this change has no impact.

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>