### PR TITLE
Allow for udev symlink following

### DIFF
--- a/drivers/udevSR.py
+++ b/drivers/udevSR.py
@@ -139,6 +139,9 @@ class udevVDI(VDI.VDI):
             iso8601 = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(s[stat.ST_CTIME]))
             self.sm_config['hotplugged_at'] = iso8601
 
+            if os.path.islink(self.path):
+                self.path = os.path.realpath(self.path)
+	
             dev = os.path.basename(self.path)
 	    info = sysdevice.stat(dev)
 	    if "size" in info.keys():


### PR DESCRIPTION
Hi,

Might be worth it to do the PR on the xapi-project directly, but I first want to get some input from you guys to see if it made sense. 

My understanding is that should properly allow for the SM attach to follow self.path when VDI.attach is called, but in case the drive `/dev/` device name changes, on SM start, it should load the vdi and get the new VDI path linked by the symlink.

Edit : I haven't done extensive testing with unplugging drives and swapping SATA ports, but a SR scan is working as expected, and attaching drives is working correctly with symlinks to `/dev/disk/by-id/` devices.

Command ran : 

```
mkdir /srv/pass_drives/
cd /srv/pass_drives/
ln -s /dev/disk/by-id/ata-WDC_WD120EFBX-68B0EN0_5QKP16YB
ln -s /dev/disk/by-id/ata-WDC_WD120EFBX-68B0EN0_5QKT00MB
ln -s /dev/disk/by-id/ata-WDC_WD120EFBX-68B0EN0_5QKT9B9B
xe sr-create name-label=Pass_Drives type=udev content-type=disk device-config:location=/srv/pass_drives
```