### PR TITLE
Remove `SR_PROBE` from ZFS capabilities

### DIFF
--- a/drivers/ZFSSR.py
+++ b/drivers/ZFSSR.py
@@ -23,7 +23,6 @@ import util
 import xs_errors
 
 CAPABILITIES = [
-    'SR_PROBE',
     'SR_UPDATE',
     'VDI_CREATE',
     'VDI_DELETE',


### PR DESCRIPTION
The probe method is not implemented so we
shouldn't advertise it.