### PR TITLE
Repair coverage to be compatible with 8.3 test env

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -838,9 +838,8 @@ class LinstorSR(SR.SR):
 
         # Update the database before the restart of the GC to avoid
         # bad sync in the process if new VDIs have been introduced.
-        ret = super(LinstorSR, self).scan(self.uuid)
+        super(LinstorSR, self).scan(self.uuid)
         self._kick_gc()
-        return ret
 
     @_locked_load
     def vdi(self, uuid):

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -84,7 +84,7 @@ ignored-classes=SQLObject
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed.
-generated-members=REQUEST,acl_users,aq_parent
+generated-members=REQUEST,acl_users,aq_parent,linstor.*
 
 # List of module names for which member attributes should not be checked
 # # (useful for modules/projects where namespaces are manipulated during runtime

--- a/tests/test_MooseFSSR.py
+++ b/tests/test_MooseFSSR.py
@@ -1,4 +1,6 @@
-import mock
+from unittest import mock
+import unittest
+
 import MooseFSSR
 import unittest
 

--- a/tests/test_ZFSSR.py
+++ b/tests/test_ZFSSR.py
@@ -1,8 +1,9 @@
+from unittest import mock
+import unittest
+
 import FileSR
-import mock
 import os
 import SR
-import unittest
 import ZFSSR
 
 


### PR DESCRIPTION
Impacted drivers: LINSTOR, MooseFS and ZFS.
- Ignore all linstor.* members during coverage, the module is not installed in github runner.
- Use mock from unittest, the old one is not found now.
- Remove useless return from LinstorSR scan method.