### PR TITLE
feat(linstor-manager): extend api to create netinterface and select preferred

### DIFF
--- a/drivers/linstor-manager
+++ b/drivers/linstor-manager
@@ -977,6 +977,51 @@ def health_check(session, args):
     return format_result()
 
 
+def create_node_interface(session, args):
+    group_name = args['groupName']
+    hostname = args['hostname']
+    name = args['name']
+    pif_uuid = args['pifUuid']
+
+    pif_ref = session.xenapi.PIF.get_by_uuid(pif_uuid)
+    pif = session.xenapi.PIF.get_record(pif_ref)
+
+    if not pif['currently_attached']:
+        raise XenAPIPlugin.Failure('-1', ['PIF is not plugged'])
+
+    ip_addr = pif['IP'] if pif['primary_address_type'].lower() == 'ipv4' else pif['IPv6'].split('/')[0]
+    if ip_addr == '':
+        raise XenAPIPlugin.Failure('-1', ['PIF has no IP'])
+
+    linstor = LinstorVolumeManager(
+        get_controller_uri(),
+        group_name,
+        logger=util.SMlog
+    )
+    try:
+        linstor.create_node_interface(hostname, name, ip_addr)
+    except Exception as e:
+        raise XenAPIPlugin.Failure('-1', [str(e)])
+    return str(True)
+
+
+def set_node_preferred_interface(session, args):
+    group_name = args['groupName']
+    hostname = args['hostname']
+    name = args['name']
+
+    linstor = LinstorVolumeManager(
+        get_controller_uri(),
+        group_name,
+        logger=util.SMlog
+    )
+    try:
+        linstor.set_node_preferred_interface(hostname, name)
+    except Exception as e:
+        raise XenAPIPlugin.Failure('-1', [str(e)])
+    return str(True)
+
+
 if __name__ == '__main__':
     XenAPIPlugin.dispatch({
         'prepareSr': prepare_sr,
@@ -1024,5 +1069,8 @@ if __name__ == '__main__':
         'destroyDrbdVolume': destroy_drbd_volume,
         'destroyDrbdVolumes': destroy_drbd_volumes,
         'getDrbdOpeners': get_drbd_openers,
-        'healthCheck': health_check
+        'healthCheck': health_check,
+
+        'createNodeInterface': create_node_interface,
+        'setNodePreferredInterface': set_node_preferred_interface
     })

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1529,6 +1529,22 @@ class LinstorVolumeManager(object):
                 'Failed to destroy node `{}`: {}'.format(node_name, error_str)
             )
 
+    def create_node_interface(self, hostname, name, ip_addr):
+        result = self._linstor.netinterface_create(hostname, name, ip_addr)
+        if not linstor.Linstor.all_api_responses_no_error(result):
+            raise LinstorVolumeManagerError(
+                'Unable to create interface on `{}`: {}'.format(hostname, ', '.join(
+                    [str(x) for x in result]))
+                )
+
+    def set_node_preferred_interface(self, hostname, name):
+        result = self._linstor.node_modify(hostname, property_dict={'PrefNic': name})
+        if not linstor.Linstor.all_api_responses_no_error(result):
+            raise LinstorVolumeManagerError(
+                'Unable to set preferred interface on `{}`: {}'.format(hostname, ', '.join(
+                    [str(x) for x in result]))
+                )
+
     def get_nodes_info(self):
         """
         Get all nodes + statuses, used or not by the pool.


### PR DESCRIPTION
New plugin method:
- interfaceCreate(groupName, hostname, ifaceName, pifUUid): create a new net interface on a pif on a linstor node
- nodeSetPreferredInterface(gropuName, hostname, ifaceName): set a network interface as preffered for a linstor node
