### PR TITLE
feat(LargeBlock): add error for multidevices

### DIFF
--- a/drivers/LargeBlockSR.py
+++ b/drivers/LargeBlockSR.py
@@ -82,6 +82,9 @@ class LargeBlockSR(EXTSR.EXTSR):
     @deviceCheck
     def create(self, sr_uuid, size):
         base_devices = self.dconf["device"].split(",")
+        if len(base_devices) > 1:
+            raise xs_errors.XenError("ConfigDeviceInvalid", opterr="Multiple devices configuration is not supported")
+
         for dev in base_devices:
             logical_blocksize = util.pread2(["blockdev", "--getss", dev]).strip()
             if logical_blocksize == "512":


### PR DESCRIPTION
Add an error to explicitly say that multi devices SR is not supported on the driver.
Before that, it would make another error:
```
Error code: SR_BACKEND_FAILURE_77
Error parameters: , Logical Volume group creation failed,
```