### PR TITLE
fix(linstorvhdutil): retry check on another machine in case of failure

### DIFF
--- a/drivers/linstor-manager
+++ b/drivers/linstor-manager
@@ -29,7 +29,7 @@ import XenAPIPlugin
 
 from json import JSONEncoder
 from linstorjournaler import LinstorJournaler
-from linstorvhdutil import LinstorVhdUtil
+from linstorvhdutil import LinstorVhdUtil, check_ex
 from linstorvolumemanager import get_controller_uri, get_local_volume_openers, LinstorVolumeManager
 from lock import Lock
 import json
@@ -390,7 +390,8 @@ def check(session, args):
             args['ignoreMissingFooter']
         )
         fast = distutils.util.strtobool(args['fast'])
-        return str(vhdutil.check(device_path, ignore_missing_footer, fast))
+        check_ex(device_path, ignore_missing_footer, fast)
+        return str(True)
     except Exception as e:
         util.SMlog('linstor-manager:check error: {}'.format(e))
         raise


### PR DESCRIPTION
I'm creating the PR now but we need to discuss it and make sure we don't miss similar issues. This commit may be incomplete or not great, we must check it when I'm available.

Context: If a call to vhd-util check fails locally, we don't try again elsewhere. The explanation is simple, the check function does not raise an exception unlike other vhdutil functions, and therefore it does not trigger our handlers in linstorvhdutil.py. The idea here is to use a function that raises if a call to `check` function doesn't pass. Otherwise it can block coalesces.