### PR TITLE
fix(linstor): Correctly remove DB files

### DIFF
--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1395,7 +1395,7 @@ class LinstorVolumeManager(object):
 
         try:
             self._start_controller(start=False)
-            for file in glob.glob(DATABASE_PATH + '/'):
+            for file in glob.glob(DATABASE_PATH + '/*'):
                 os.remove(file)
         except Exception as e:
             util.SMlog(

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -18,7 +18,6 @@
 
 import distutils.util
 import errno
-import glob
 import json
 import linstor
 import os.path
@@ -1395,8 +1394,9 @@ class LinstorVolumeManager(object):
 
         try:
             self._start_controller(start=False)
-            for file in glob.glob(DATABASE_PATH + '/*'):
-                os.remove(file)
+            ignored = ('lost+found')
+            for file in filter(lambda file: file not in ignored, os.listdir(DATABASE_PATH)):
+                os.remove(DATABASE_PATH + '/' + file)
         except Exception as e:
             util.SMlog(
                 'Ignoring failure after LINSTOR SR destruction: {}'

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1394,9 +1394,9 @@ class LinstorVolumeManager(object):
 
         try:
             self._start_controller(start=False)
-            ignored = ('lost+found')
-            for file in filter(lambda file: file not in ignored, os.listdir(DATABASE_PATH)):
-                os.remove(DATABASE_PATH + '/' + file)
+            for file in os.listdir(DATABASE_PATH):
+                if file != 'lost+found':
+                    os.remove(DATABASE_PATH + '/' + file)
         except Exception as e:
             util.SMlog(
                 'Ignoring failure after LINSTOR SR destruction: {}'


### PR DESCRIPTION
`glob` method only returns the dir when not wildcard is used in the path.
Therefore the remove call right after will fail everytime.