### PR TITLE
fix: getAllocatedSize is incorrect

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -1193,6 +1193,11 @@ class FileVDI(VDI):
             raise util.SMException("os.unlink(%s) failed" % self.path)
         VDI.delete(self)
 
+    def getAllocatedSize(self):
+        if self._sizeAllocated == -1:
+            self._sizeAllocated = vhdutil.getAllocatedSize(self.path)
+        return self._sizeAllocated
+
 
 class LVHDVDI(VDI):
     """Object representing a VDI in an LVHD SR"""

--- a/drivers/vhdutil.py
+++ b/drivers/vhdutil.py
@@ -94,6 +94,11 @@ def ioretry(cmd, text=True):
                         errlist=[errno.EIO, errno.EAGAIN])
 
 
+def convertAllocatedSizeToBytes(size):
+    # Assume we have standard 2MB allocation blocks
+    return size * 2 * 1024 * 1024
+
+
 def getVHDInfo(path, extractUuidFunction, includeParent=True, resolveParent=True):
     """Get the VHD info. The parent info may optionally be omitted: vhd-util
     tries to verify the parent by opening it, which results in error if the VHD
@@ -118,7 +123,7 @@ def getVHDInfo(path, extractUuidFunction, includeParent=True, resolveParent=True
             vhdInfo.parentUuid = extractUuidFunction(fields[nextIndex])
         nextIndex += 1
     vhdInfo.hidden = int(fields[nextIndex].replace("hidden: ", ""))
-    vhdInfo.sizeAllocated = int(fields[nextIndex+1])
+    vhdInfo.sizeAllocated = convertAllocatedSizeToBytes(int(fields[nextIndex+1]))
     vhdInfo.path = path
     return vhdInfo
 
@@ -277,8 +282,7 @@ def setSizePhys(path, size, debug=True):
 def getAllocatedSize(path):
     cmd = [VHD_UTIL, "query", OPT_LOG_ERR, '-a', '-n', path]
     ret = ioretry(cmd)
-    # Assume we have standard 2MB allocation blocks
-    return int(ret) * 2 * 1024 * 1024
+    return convertAllocatedSizeToBytes(int(ret))
 
 def killData(path):
     "zero out the disk (kill all data inside the VHD file)"

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1365,6 +1365,7 @@ class TestSR(unittest.TestCase):
         vdi = cleanup.FileVDI(sr, vdi_uuid, False)
         vdi.path = '%s.vhd' % (vdi_uuid)
         vdi.parent = parent
+        vdi._sizeAllocated = 20971520 #10 blocks of 2MB changed in the child
         parent.children.append(vdi)
 
         sr.vdis[vdi_uuid] = vdi


### PR DESCRIPTION
The `VDI.canLiveCoalesce` method can manipulates sizes of different units because of this change:
```
CP-40871: use VHD allocation size in checking canLiveCoalesce
2f863b9fce6f2978499892d8c019bb3ab7ad72c5
```
As a result, the `canLiveCoalesce` method can return `True` and cause coalesce attempts
resulting in "Timed out" exceptions.

* Only drivers deriving from `FileSR` are impacted.

* The size of `self._sizeAllocated` is calculated correctly when `vhdutil.getAllocatedSize`
is called but there is a problematic case where `getVHDInfo` is used instead.
And this function does not convert `info.sizeAllocated` from block size to bytes.

* Additionally, the getter `getAllocatedSize` should retrieve the allocated size if it's equal to -1.
Otherwise `VDI.canLiveCoalesce` can compare -1 to a positive value and would always return `True`
causing a `Timed out` error error...