### PR TITLE
(8.3) Fix filter to reject other device types than NVMe

### DIFF
--- a/drivers/LargeBlockSR.py
+++ b/drivers/LargeBlockSR.py
@@ -224,7 +224,7 @@ class LargeBlockSR(EXTSR.EXTSR):
         util.SMlog("Reconnecting VG {} to use emulated device".format(self.vgname))
         try:
             lvutil.setActiveVG(self.vgname, False)
-            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"r|^/dev/nvme.*|\", \"a|/dev/loop.*|\" ] }")
+            lvutil.setActiveVG(self.vgname, True, config="devices{ global_filter = [ \"a|/dev/loop.*|\", \"r|.*|\" ] }")
         except util.CommandException as e:
             xs_errors.XenError("LargeBlockVGReconnectFailed", opterr="Failed to reconnect the VolumeGroup {}, error: {}".format(self.vgname, e))
 


### PR DESCRIPTION
If the 4KiB blocksize device is not a NVMe, the global_filter for VG activation is incorrect. Meaning the VG could enable on top of the real device and the VDI creation will not work.
This new filter disable everything but the loop devices.