### PR TITLE
fix(cleanup.py): protect LinstorSR init against race condition

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -3221,7 +3221,7 @@ class LinstorSR(SR):
 
         SR.__init__(self, uuid, xapi, createLock, force)
         self.path = LinstorVolumeManager.DEV_ROOT_PATH
-        self._reloadLinstor()
+        self._reloadLinstor(journaler_only=True)
 
     @override
     def deleteVDI(self, vdi) -> None:
@@ -3256,7 +3256,7 @@ class LinstorSR(SR):
         )
         return super(LinstorSR, self).pauseVDIs(vdiList)
 
-    def _reloadLinstor(self):
+    def _reloadLinstor(self, journaler_only=False):
         session = self.xapi.session
         host_ref = util.get_this_host_ref(session)
         sr_ref = session.xenapi.SR.get_by_uuid(self.uuid)
@@ -3272,6 +3272,9 @@ class LinstorSR(SR):
         self.journaler = LinstorJournaler(
             controller_uri, group_name, logger=util.SMlog
         )
+
+        if journaler_only:
+            return
 
         self._linstor = LinstorVolumeManager(
             controller_uri,


### PR DESCRIPTION
During `LinstorSR` init, only create the journaler to make `should_preempt` happy. The volume manager MUST always be created in a SR lock context. Otherwise, we can trigger major issues.

For example, a volume can be deleted from the KV-store by `cleanup.py` during a snapshot rollback. Very rare situation but which allowed this problem to be discovered.