### PR TITLE
3.2.3 8.3 add udev rules optimization for PureStorage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ SM_LIBS += constants
 SM_LIBS += cbtutil
 SM_LIBS += sr_health_check
 
-UDEV_RULES = 65-multipath 55-xs-mpath-scsidev 57-usb 58-xapi
+UDEV_RULES = 65-multipath 55-xs-mpath-scsidev 57-usb 58-xapi 99-purestorage
 MPATH_DAEMON = sm-multipath
 MPATH_CONF = multipath.conf
 MPATH_CUSTOM_CONF = custom.conf

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -222,6 +222,7 @@ tests/run_python_unittests.sh
 %config /etc/udev/rules.d/69-dm-lvm-metad.rules
 %config /etc/logrotate.d/SMlog
 %config /etc/udev/rules.d/57-usb.rules
+%config /etc/udev/rules.d/99-purestorage.rules
 %doc CONTRIB LICENSE MAINTAINERS README.md
 
 %package fairlock

--- a/udev/99-purestorage.rules
+++ b/udev/99-purestorage.rules
@@ -1,0 +1,15 @@
+# Recommended settings for Pure Storage FlashArray.
+# Use none scheduler for high-performance solid-state storage for SCSI devices
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/scheduler}="none"
+
+# Reduce CPU overhead due to entropy collection
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/add_random}="0"
+ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/add_random}="0"
+
+# Spread CPU load by redirecting completions to originating CPU
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/rq_affinity}="2"
+ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/rq_affinity}="2"
+
+# Set the HBA timeout to 60 seconds
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{device/timeout}="60"


### PR DESCRIPTION
Apply the PureStorage KB best practice for I/O scheduler. 
