### PR TITLE
fix(cleanup.py): resize on a primary host

### DIFF
--- a/drivers/linstor-manager
+++ b/drivers/linstor-manager
@@ -477,6 +477,15 @@ def get_size_phys(session, args):
         raise
 
 
+def get_max_resize_size(session, args):
+    try:
+        device_path = args['devicePath']
+        return str(vhdutil.getMaxResizeSize(device_path))
+    except Exception as e:
+        util.SMlog('linstor-manager:get_size_phys error: {}'.format(e))
+        raise
+
+
 def get_depth(session, args):
     try:
         device_path = args['devicePath']
@@ -513,6 +522,29 @@ def get_drbd_size(session, args):
         raise Exception('Failed to get DRBD size: {}'.format(stderr))
     except Exception:
         util.SMlog('linstor-manager:get_drbd_size error: {}'.format(stderr))
+        raise
+
+
+def set_size_virt(session, args):
+    try:
+        device_path = args['devicePath']
+        size = int(args['size'])
+        jfile = args['jfile']
+        vhdutil.setSizeVirt(device_path, size, jfile)
+        return ''
+    except Exception as e:
+        util.SMlog('linstor-manager:set_size_virt error: {}'.format(e))
+        raise
+
+
+def set_size_virt_fast(session, args):
+    try:
+        device_path = args['devicePath']
+        size = int(args['size'])
+        vhdutil.setSizeVirtFast(device_path, size)
+        return ''
+    except Exception as e:
+        util.SMlog('linstor-manager:set_size_virt_fast error: {}'.format(e))
         raise
 
 
@@ -1204,6 +1236,7 @@ if __name__ == '__main__':
         'hasParent': has_parent,
         'getParent': get_parent,
         'getSizeVirt': get_size_virt,
+        'getMaxResizeSize': get_max_resize_size,
         'getSizePhys': get_size_phys,
         'getDepth': get_depth,
         'getKeyHash': get_key_hash,
@@ -1214,6 +1247,8 @@ if __name__ == '__main__':
 
         # Called by cleanup.py to coalesce when a primary
         # is opened on a non-local host.
+        'setSizeVirt': set_size_virt,
+        'setSizeVirtFast': set_size_virt_fast,
         'setParent': set_parent,
         'coalesce': coalesce,
         'repair': repair,

--- a/drivers/linstorjournaler.py
+++ b/drivers/linstorjournaler.py
@@ -44,6 +44,7 @@ class LinstorJournaler:
     """
     CLONE = 'clone'
     INFLATE = 'inflate'
+    ZERO = 'zero'
 
     @staticmethod
     def default_logger(*args):

--- a/drivers/linstorvhdutil.py
+++ b/drivers/linstorvhdutil.py
@@ -267,6 +267,10 @@ class LinstorVhdUtil:
     def get_size_virt(self, vdi_uuid, response):
         return int(response)
 
+    @linstorhostcall(vhdutil.getMaxResizeSize, 'getMaxResizeSize')
+    def get_max_resize_size(self, vdi_uuid, response):
+        return int(response)
+
     @linstorhostcall(vhdutil.getSizePhys, 'getSizePhys')
     def get_size_phys(self, vdi_uuid, response):
         return int(response)
@@ -300,14 +304,6 @@ class LinstorVhdUtil:
     @linstormodifier()
     def create(self, path, size, static, msize=0):
         return self._call_local_method_or_fail(vhdutil.create, path, size, static, msize)
-
-    @linstormodifier()
-    def set_size_virt(self, path, size, jfile):
-        return self._call_local_method_or_fail(vhdutil.setSizeVirt, path, size, jfile)
-
-    @linstormodifier()
-    def set_size_virt_fast(self, path, size):
-        return self._call_local_method_or_fail(vhdutil.setSizeVirtFast, path, size)
 
     @linstormodifier()
     def set_size_phys(self, path, size, debug=True):
@@ -382,6 +378,21 @@ class LinstorVhdUtil:
     # --------------------------------------------------------------------------
     # Remote setters: write locally and try on another host in case of failure.
     # --------------------------------------------------------------------------
+
+    @linstormodifier()
+    def set_size_virt(self, path, size, jfile):
+        kwargs = {
+            'size': size,
+            'jfile': jfile
+        }
+        return self._call_method(vhdutil.setSizeVirt, 'setSizeVirt', path, use_parent=False, **kwargs)
+
+    @linstormodifier()
+    def set_size_virt_fast(self, path, size):
+        kwargs = {
+            'size': size
+        }
+        return self._call_method(vhdutil.setSizeVirtFast, 'setSizeVirtFast', path, use_parent=False, **kwargs)
 
     @linstormodifier()
     def force_parent(self, path, parentPath, parentRaw=False):


### PR DESCRIPTION
Until now the cleanup VHD resize commands were performed on the master. But it doesn't work every time when a VHD of a chain is opened for reading on another host.

As a reminder, this portion of code is only executed rarely. A user must have resized a VHD that must later be coalesced.