### PR TITLE
Improve LinstorSR.py to handle thick SR creation

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -586,7 +586,7 @@ class LinstorSR(SR.SR):
                 opterr='LINSTOR SR must be unique in a pool'
             )
 
-        online_hosts = util.get_online_hosts(self.session)
+        online_hosts = util.get_enabled_hosts(self.session)
         if len(online_hosts) < len(host_adresses):
             raise xs_errors.XenError(
                 'LinstorSRCreate',

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -777,6 +777,12 @@ def get_slaves_attached_on(session, vdi_uuids):
     master_ref = get_this_host_ref(session)
     return [x for x in host_refs if x != master_ref]
 
+def get_enabled_hosts(session):
+    """
+    Returns a list of host refs that are enabled in the pool.
+    """
+    enabled_hosts = list(session.xenapi.host.get_all_records_where('field "enabled" = "true"').keys())
+    return enabled_hosts
 
 def get_online_hosts(session):
     online_hosts = []

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -781,8 +781,7 @@ def get_enabled_hosts(session):
     """
     Returns a list of host refs that are enabled in the pool.
     """
-    enabled_hosts = list(session.xenapi.host.get_all_records_where('field "enabled" = "true"').keys())
-    return enabled_hosts
+    return list(session.xenapi.host.get_all_records_where('field "enabled" = "true"').keys())
 
 def get_online_hosts(session):
     online_hosts = []


### PR DESCRIPTION
In some cases `thick` SR creation may fail due to `get_online_hosts` as the metrics could take time. Thus, changed the mechanism to `get_enabled_hosts`.