### PR TITLE
Fix LINSTOR satellite LS_KEEP_RES regex

### DIFF
--- a/etc/systemd/system/linstor-satellite.service.d/override.conf
+++ b/etc/systemd/system/linstor-satellite.service.d/override.conf
@@ -1,5 +1,5 @@
 [Service]
-Environment=LS_KEEP_RES=^xcp-persistent*
+Environment=LS_KEEP_RES=^xcp-persistent.*
 
 [Unit]
 After=drbd.service


### PR DESCRIPTION
The regex is not correct: luckily it matches resources like `xcp-persistent-database` but also these resources: `xcp-persisten`, `xcp-persistenttttttt`...