### PR TITLE
feat: linstorhostcall rewrite

### DIFF
--- a/drivers/linstorvhdutil.py
+++ b/drivers/linstorvhdutil.py
@@ -77,6 +77,17 @@ class ErofsLinstorCallException(LinstorCallException):
 class NoPathLinstorCallException(LinstorCallException):
     pass
 
+def log_successful_call(target_host, device_path, vdi_uuid, remote_method, response):
+    util.SMlog(
+        'Successful access on {} for device {} ({}): `{}` => {}'.format(target_host, device_path, vdi_uuid, remote_method, str(response)),
+        priority=util.LOG_DEBUG
+    )
+
+def log_failed_call(target_host, next_target, device_path, vdi_uuid, remote_method, e):
+    util.SMlog(
+        'Failed to call method on {} for device {} ({}): {}. Trying accessing on {}... (cause: {})'.format(target_host, device_path, vdi_uuid, remote_method, next_target, e),
+        priority=util.LOG_DEBUG
+    )
 
 def linstorhostcall(local_method, remote_method):
     def decorated(response_parser):
@@ -101,39 +112,36 @@ def linstorhostcall(local_method, remote_method):
                     response = call_remote_method(
                         self._session, host_ref_attached, remote_method, device_path, remote_args
                     )
+                    log_successful_call('attached node', device_path, vdi_uuid, remote_method, response)
                     return response_parser(self, vdi_uuid, response)
             except Exception as e:
-                util.SMlog(
-                    'Failed to call method on attached host. Trying local access... (cause: {})'.format(e),
-                    priority=util.LOG_DEBUG
-                )
+                log_failed_call('attached node', 'master', device_path, vdi_uuid, remote_method, e)
 
             try:
                 master_ref = self._session.xenapi.pool.get_all_records().values()[0]['master']
                 response = call_remote_method(self._session, master_ref, remote_method, device_path, remote_args)
+                log_successful_call('master', device_path, vdi_uuid, remote_method, response)
                 return response_parser(self, vdi_uuid, response)
             except Exception as e:
-                util.SMlog(
-                    'Failed to call method on master host. Finding primary node... (cause: {})'.format(e),
-                    priority=util.LOG_DEBUG
-                )
+                log_failed_call('master', 'primary', device_path, vdi_uuid, remote_method, e)
+
 
             nodes, primary_hostname = self._linstor.find_up_to_date_diskful_nodes(vdi_uuid)
             if primary_hostname:
                 try:
                     host_ref = self._get_readonly_host(vdi_uuid, device_path, {primary_hostname})
                     response = call_remote_method(self._session, host_ref, remote_method, device_path, remote_args)
+                    log_successful_call('primary', device_path, vdi_uuid, remote_method, response)
                     return response_parser(self, vdi_uuid, response)
                 except Exception as remote_e:
                     self._raise_openers_exception(device_path, remote_e)
             else:
-                util.SMlog(
-                    'Couldn\'t get primary for {}. Trying with another node...'.format(vdi_uuid),
-                    priority=util.LOG_DEBUG
-                )
+                log_failed_call('primary', 'another node', device_path, vdi_uuid, remote_method, e)
+
                 try:
                     host = self._get_readonly_host(vdi_uuid, device_path, nodes)
                     response = call_remote_method(self._session, host, remote_method, device_path, remote_args)
+                    log_successful_call('another node', device_path, vdi_uuid, remote_method, response)
                     return response_parser(self, vdi_uuid, response)
                 except Exception as remote_e:
                     self._raise_openers_exception(device_path, remote_e)

--- a/drivers/linstorvhdutil.py
+++ b/drivers/linstorvhdutil.py
@@ -31,18 +31,21 @@ MANAGER_PLUGIN = 'linstor-manager'
 
 
 def call_remote_method(session, host_ref, method, device_path, args):
+    host_rec = session.xenapi.host.get_record(host_ref)
+    host_uuid = host_rec['uuid']
+
     try:
         response = session.xenapi.host.call_plugin(
             host_ref, MANAGER_PLUGIN, method, args
         )
     except Exception as e:
-        util.SMlog('call-plugin ({} with {}) exception: {}'.format(
-            method, args, e
+        util.SMlog('call-plugin on {} ({} with {}) exception: {}'.format(
+            host_uuid, method, args, e
         ))
         raise util.SMException(str(e))
 
-    util.SMlog('call-plugin ({} with {}) returned: {}'.format(
-        method, args, response
+    util.SMlog('call-plugin on {} ({} with {}) returned: {}'.format(
+        host_uuid, method, args, response
     ))
 
     return response
@@ -85,33 +88,6 @@ def linstorhostcall(local_method, remote_method):
                 self._linstor.get_volume_name(vdi_uuid)
             )
 
-            # A. Try a call using directly the DRBD device to avoid
-            # remote request.
-
-            # Try to read locally if the device is not in use or if the device
-            # is up to date and not diskless.
-            (node_names, in_use_by) = \
-                self._linstor.find_up_to_date_diskful_nodes(vdi_uuid)
-
-            local_e = None
-            try:
-                if not in_use_by or socket.gethostname() in node_names:
-                    return self._call_local_method(local_method, device_path, *args[2:], **kwargs)
-            except ErofsLinstorCallException as e:
-                local_e = e.cmd_err
-            except Exception as e:
-                local_e = e
-
-            util.SMlog(
-                'unable to execute `{}` locally, retry using a readable host... (cause: {})'.format(
-                    remote_method, local_e if local_e else 'local diskless + in use or not up to date'
-                )
-            )
-
-            if in_use_by:
-                node_names = {in_use_by}
-
-            # B. Execute the plugin on master or slave.
             remote_args = {
                 'devicePath': device_path,
                 'groupName': self._linstor.group_name
@@ -120,14 +96,48 @@ def linstorhostcall(local_method, remote_method):
             remote_args = {str(key): str(value) for key, value in remote_args.items()}
 
             try:
-                def remote_call():
-                    host_ref = self._get_readonly_host(vdi_uuid, device_path, node_names)
-                    return call_remote_method(self._session, host_ref, remote_method, device_path, remote_args)
-                response = util.retry(remote_call, 5, 2)
-            except Exception as remote_e:
-                self._raise_openers_exception(device_path, local_e or remote_e)
+                host_ref_attached = util.get_hosts_attached_on(self._session, [vdi_uuid])[0]
+                if host_ref_attached:
+                    response = call_remote_method(
+                        self._session, host_ref_attached, remote_method, device_path, remote_args
+                    )
+                    return response_parser(self, vdi_uuid, response)
+            except Exception as e:
+                util.SMlog(
+                    'Failed to call method on attached host. Trying local access... (cause: {})'.format(e),
+                    priority=util.LOG_DEBUG
+                )
 
-            return response_parser(self, vdi_uuid, response)
+            try:
+                master_ref = self._session.xenapi.pool.get_all_records().values()[0]['master']
+                response = call_remote_method(self._session, master_ref, remote_method, device_path, remote_args)
+                return response_parser(self, vdi_uuid, response)
+            except Exception as e:
+                util.SMlog(
+                    'Failed to call method on master host. Finding primary node... (cause: {})'.format(e),
+                    priority=util.LOG_DEBUG
+                )
+
+            nodes, primary_hostname = self._linstor.find_up_to_date_diskful_nodes(vdi_uuid)
+            if primary_hostname:
+                try:
+                    host_ref = self._get_readonly_host(vdi_uuid, device_path, {primary_hostname})
+                    response = call_remote_method(self._session, host_ref, remote_method, device_path, remote_args)
+                    return response_parser(self, vdi_uuid, response)
+                except Exception as remote_e:
+                    self._raise_openers_exception(device_path, remote_e)
+            else:
+                util.SMlog(
+                    'Couldn\'t get primary for {}. Trying with another node...'.format(vdi_uuid),
+                    priority=util.LOG_DEBUG
+                )
+                try:
+                    host = self._get_readonly_host(vdi_uuid, device_path, nodes)
+                    response = call_remote_method(self._session, host, remote_method, device_path, remote_args)
+                    return response_parser(self, vdi_uuid, response)
+                except Exception as remote_e:
+                    self._raise_openers_exception(device_path, remote_e)
+
         return wrapper
     return decorated
 

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1439,6 +1439,24 @@ class LinstorVolumeManager(object):
 
         return (node_names, in_use_by)
 
+    def get_primary(self, volume_uuid):
+        """
+        Find the node that opened a volume, i.e. the primary.
+        :rtype: str
+        """
+        volume_name = self.get_volume_name(volume_uuid)
+
+        resource_states = filter(
+            lambda resource_state: resource_state.name == volume_name,
+            self._get_resource_cache().resource_states
+        )
+
+        for resource_state in resource_states:
+            if resource_state.in_use:
+                return resource_state.node_name
+
+        return None
+
     def invalidate_resource_cache(self):
         """
         If resources are impacted by external commands like vhdutil,

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1058,7 +1058,7 @@ class LinstorVolumeManager(object):
 
             # 5. Ok!
             volume_properties[self.PROP_NOT_EXISTS] = self.STATE_EXISTS
-        except Exception as e:
+        except Exception as err:
             try:
                 # Clear the new volume properties in case of failure.
                 assert volume_properties.namespace == \
@@ -1070,7 +1070,7 @@ class LinstorVolumeManager(object):
                     .format(e)
                 )
             raise LinstorVolumeManagerError(
-                'Failed to copy volume properties: {}'.format(e)
+                'Failed to copy volume properties: {}'.format(err)
             )
 
         try:
@@ -1438,24 +1438,6 @@ class LinstorVolumeManager(object):
                 in_use_by = resource_state.node_name
 
         return (node_names, in_use_by)
-
-    def get_primary(self, volume_uuid):
-        """
-        Find the node that opened a volume, i.e. the primary.
-        :rtype: str
-        """
-        volume_name = self.get_volume_name(volume_uuid)
-
-        resource_states = filter(
-            lambda resource_state: resource_state.name == volume_name,
-            self._get_resource_cache().resource_states
-        )
-
-        for resource_state in resource_states:
-            if resource_state.in_use:
-                return resource_state.node_name
-
-        return None
 
     def invalidate_resource_cache(self):
         """


### PR DESCRIPTION
cherry-picked commits ([160db7d](https://github.com/xcp-ng/sm/commit/160db7dd10ab6593ea019727a88f1bc1d4594ffe) and [0bba929](https://github.com/xcp-ng/sm/commit/0bba9299822c5446c71a59b7b5440cfbead10c7a)) from [2.30.8-8.2-linstor-fixes-staging](https://github.com/xcp-ng/sm/commits/2.30.8-8.2-linstor-fixes-staging/).

Also adds two fixes about access before assignment on exceptions, the latter being crucial for this PR to work.