### PR TITLE
fix(linstorvolumemanager): create local DB path when required

### DIFF
--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1747,7 +1747,7 @@ class LinstorVolumeManager(object):
         :return: The current database path.
         :rtype: str
         """
-        return self._request_database_path(self._linstor)
+        return self._request_database_path(self._linstor, activate=True)
 
     @classmethod
     def get_all_group_names(cls, base_name):


### PR DESCRIPTION
When the pool master is changed and if it doesn't have a local DB path then `get_database_path` fails during SR.scan call. This patch allows creating a diskless path if necessary.