### PR TITLE
LVHDSR: convert refvdi retured by get_snapshot_of to vdi_uuid

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -261,6 +261,7 @@ class LVHDSR(SR.SR):
             vdi_info = {}
             for vdi in self.session.xenapi.SR.get_VDIs(self.sr_ref):
                 vdi_uuid = self.session.xenapi.VDI.get_uuid(vdi)
+                is_a_snapshot = int(self.session.xenapi.VDI.get_is_a_snapshot(vdi))
 
                 # Create the VDI entry in the SR metadata
                 vdi_info[vdi_uuid] = \
@@ -269,9 +270,9 @@ class LVHDSR(SR.SR):
                     NAME_LABEL_TAG: util.to_plain_string(self.session.xenapi.VDI.get_name_label(vdi)),
                     NAME_DESCRIPTION_TAG: util.to_plain_string(self.session.xenapi.VDI.get_name_description(vdi)),
                     IS_A_SNAPSHOT_TAG: \
-                        int(self.session.xenapi.VDI.get_is_a_snapshot(vdi)),
+                        is_a_snapshot,
                     SNAPSHOT_OF_TAG: \
-                        self.session.xenapi.VDI.get_snapshot_of(vdi),
+                        self.session.xenapi.VDI.get_uuid(self.session.xenapi.VDI.get_snapshot_of(vdi)) if bool(is_a_snapshot) else '',
                    SNAPSHOT_TIME_TAG: \
                         self.session.xenapi.VDI.get_snapshot_time(vdi),
                     TYPE_TAG: \

--- a/drivers/srmetadata.py
+++ b/drivers/srmetadata.py
@@ -705,7 +705,6 @@ class LVMMetadataHandler(MetadataHandler):
             if created:
                 # Now delete the dummy VDI created above
                 self.deleteVdi(uuid)
-                return
 
     # This function generates VDI info based on the passed in information
     # it also takes in a parameter to determine whether both the sector


### PR DESCRIPTION
According to xapi doc, VDI.get_snapshot_of returns a VDI.ref.