### PR TITLE
fix(ci): hotfix for broken ci

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-coverage
+coverage<7.11
 astroid
 pylint
 bitarray


### PR DESCRIPTION
Restrict `coverage` version to avoid broken ci