### PR TITLE
chore(ci): build using python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.8' # This version is the closest available to the one currently used in production (3.6).
 
       - name: Install dependencies
         run: |

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-coverage<7.11
+coverage
 astroid
 pylint
 bitarray


### PR DESCRIPTION
Avoid python version mismatch that pulls incompatible dependencies in github actions when running unittests