### PR TITLE
fix(linstor): print DRBDs open during chain check in RO mode

### DIFF
--- a/drivers/linstorvhdutil.py
+++ b/drivers/linstorvhdutil.py
@@ -191,8 +191,8 @@ class LinstorVhdUtil:
                         if e.errno == errno.ENODATA:
                             time.sleep(2)
                             continue
-                        if e.errno == errno.EROFS:
-                            util.SMlog('Volume not attachable because RO. Openers: {}'.format(
+                        if e.errno == errno.EROFS or e.errno == errno.EMEDIUMTYPE:
+                            util.SMlog('Volume not attachable because used. Openers: {}'.format(
                                 self._linstor.get_volume_openers(vdi_uuid)
                             ))
                         raise


### PR DESCRIPTION
Before this change `EMEDIUMTYPE` was not tested, so we only checked the DRBD openers if we attempted a local opening in write mode.

As a reminder, `EMEDIUMTYPE` is returned if a local read-only opening is attempted and the volume is open for writing on another machine.