### PR TITLE
Fix a crash with cleanup operation while a host is offline.

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -3000,7 +3000,7 @@ class FileSR(SR):
                 raise AbortException("Aborting due to signal")
             try:
                 self._checkSlave(hostRef, vdi)
-            except util.CommandException:
+            except XenAPI.Failure:
                 if hostRef in onlineHosts:
                     raise
 


### PR DESCRIPTION
When checking attached hosts, the exception to ignore for offline hosts is XenAPI.Failure.