### PR TITLE
Linstor: db backup on major operations, and regularly on check_sr

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -35,11 +35,8 @@ except ImportError:
     LINSTOR_AVAILABLE = False
 
 from lock import Lock
-from datetime import datetime
-from glob import glob
 import blktap2
 import cleanup
-import contextlib
 import errno
 import functools
 import lvutil
@@ -136,12 +133,6 @@ OPS_EXCLUSIVE = [
     'sr_update', 'sr_probe', 'vdi_init', 'vdi_create', 'vdi_delete',
     'vdi_attach', 'vdi_detach', 'vdi_clone', 'vdi_snapshot',
 ]
-
-BACKUPDB_NAME_FORMAT = "backupdb-{}-{}"
-BACKUPDB_PATH_FORMAT = "/var/lib/linstor/{}.zip"
-BACKUPDB_PATH_LATEST = BACKUPDB_PATH_FORMAT.format("backupdb-latest")
-BACKUPDB_RETENTION = 10
-BACKUPDB_DATE_FORMAT = "%Y%m%d_%H%M%S"
 
 # ==============================================================================
 # Misc helpers used by LinstorSR and linstor-thin plugin.
@@ -820,7 +811,7 @@ class LinstorSR(SR.SR):
 
     @override
     def check_sr(self, sr_uuid) -> None:
-        self._make_backupdb("auto", delay=3600)
+        self.backupdb("auto", delay=3600)
 
 
     @override
@@ -1572,36 +1563,10 @@ class LinstorSR(SR.SR):
         util.SMlog('Kicking GC')
         cleanup.start_gc_service(self.uuid)
 
-    def _backup_db_search(self, name="*"):
-        return sorted(glob(
-            BACKUPDB_PATH_FORMAT.format(BACKUPDB_NAME_FORMAT).format("*", name)
-        ))
-
-    def _make_backupdb(self, name, delay=None):
+    def backupdb(self, name, delay=0):
         if not self._linstor:
             self._reconnect()
-
-        now = datetime.now()
-        # Throttling to avoid too many backups of the same kind on a short period
-        if delay:
-            latest_named_backupdb = self._backup_db_search(name)
-            if latest_named_backupdb:
-                backupdb_date = datetime.strptime(
-                    latest_named_backupdb[-1].split("-")[1],
-                    BACKUPDB_DATE_FORMAT,
-                )
-                if (now - backupdb_date).seconds < delay:
-                    return  # No backup for now
-
-        backupdb_name = BACKUPDB_NAME_FORMAT.format(now.strftime(BACKUPDB_DATE_FORMAT), name)
-        self._linstor._linstor.controller_backupdb(backupdb_name)
-        with contextlib.suppress(OSError):
-            os.unlink(BACKUPDB_PATH_LATEST)
-            os.link(BACKUPDB_PATH_FORMAT.format(backupdb_name), BACKUPDB_PATH_LATEST)
-
-        # And keep only 10 named backups
-        for old_backupdb_file in self._backup_db_search()[:-BACKUPDB_RETENTION]:
-            os.unlink(old_backupdb_file)
+        self._linstor.backupdb(name, delay)
 
 # ==============================================================================
 # LinstorSr VDI
@@ -1802,7 +1767,7 @@ class LinstorVDI(VDI.VDI):
         self.ref = self._db_introduce()
         self.sr._update_stats(self.size)
 
-        self.sr._make_backupdb("create")
+        self.sr.backupdb("create")
 
         return VDI.VDI.get_params(self)
 
@@ -1852,7 +1817,7 @@ class LinstorVDI(VDI.VDI):
         self.sr._update_stats(-self.size)
         self.sr._kick_gc()
         super(LinstorVDI, self).delete(sr_uuid, vdi_uuid, data_only)
-        self.sr._make_backupdb("delete")
+        self.sr.backupdb("delete")
 
     @override
     def attach(self, sr_uuid, vdi_uuid) -> str:
@@ -2424,7 +2389,7 @@ class LinstorVDI(VDI.VDI):
             raise util.SMException('Failed to pause VDI {}'.format(vdi_uuid))
         try:
             r = self._snapshot(snapType, cbtlog, consistency_state)
-            self.sr._make_backupdb("snapshot")
+            self.sr.backupdb("snapshot")
             return r
         finally:
             self.disable_leaf_on_secondary(vdi_uuid, secondary=secondary)

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -35,8 +35,11 @@ except ImportError:
     LINSTOR_AVAILABLE = False
 
 from lock import Lock
+from datetime import datetime
+from glob import glob
 import blktap2
 import cleanup
+import contextlib
 import errno
 import functools
 import lvutil
@@ -133,6 +136,12 @@ OPS_EXCLUSIVE = [
     'sr_update', 'sr_probe', 'vdi_init', 'vdi_create', 'vdi_delete',
     'vdi_attach', 'vdi_detach', 'vdi_clone', 'vdi_snapshot',
 ]
+
+BACKUPDB_NAME_FORMAT = "backupdb-{}-{}"
+BACKUPDB_PATH_FORMAT = "/var/lib/linstor/{}.zip"
+BACKUPDB_PATH_LATEST = BACKUPDB_PATH_FORMAT.format("backupdb-latest")
+BACKUPDB_RETENTION = 10
+BACKUPDB_DATE_FORMAT = "%Y%m%d_%H%M%S"
 
 # ==============================================================================
 # Misc helpers used by LinstorSR and linstor-thin plugin.
@@ -808,6 +817,11 @@ class LinstorSR(SR.SR):
                 self._is_master = self.dconf['SRmaster'] == 'true'
 
         return self._is_master
+
+    @override
+    def check_sr(self, sr_uuid) -> None:
+        self._make_backupdb("auto", delay=3600)
+
 
     @override
     @_locked_load
@@ -1558,6 +1572,37 @@ class LinstorSR(SR.SR):
         util.SMlog('Kicking GC')
         cleanup.start_gc_service(self.uuid)
 
+    def _backup_db_search(self, name="*"):
+        return sorted(glob(
+            BACKUPDB_PATH_FORMAT.format(BACKUPDB_NAME_FORMAT).format("*", name)
+        ))
+
+    def _make_backupdb(self, name, delay=None):
+        if not self._linstor:
+            self._reconnect()
+
+        now = datetime.now()
+        # Throttling to avoid too many backups of the same kind on a short period
+        if delay:
+            latest_named_backupdb = self._backup_db_search(name)
+            if latest_named_backupdb:
+                backupdb_date = datetime.strptime(
+                    latest_named_backupdb[-1].split("-")[1],
+                    BACKUPDB_DATE_FORMAT,
+                )
+                if (now - backupdb_date).seconds < delay:
+                    return  # No backup for now
+
+        backupdb_name = BACKUPDB_NAME_FORMAT.format(now.strftime(BACKUPDB_DATE_FORMAT), name)
+        self._linstor._linstor.controller_backupdb(backupdb_name)
+        with contextlib.suppress(OSError):
+            os.unlink(BACKUPDB_PATH_LATEST)
+            os.link(BACKUPDB_PATH_FORMAT.format(backupdb_name), BACKUPDB_PATH_LATEST)
+
+        # And keep only 10 named backups
+        for old_backupdb_file in self._backup_db_search()[:-BACKUPDB_RETENTION]:
+            os.unlink(old_backupdb_file)
+
 # ==============================================================================
 # LinstorSr VDI
 # ==============================================================================
@@ -1757,6 +1802,8 @@ class LinstorVDI(VDI.VDI):
         self.ref = self._db_introduce()
         self.sr._update_stats(self.size)
 
+        self.sr._make_backupdb("create")
+
         return VDI.VDI.get_params(self)
 
     @override
@@ -1804,7 +1851,8 @@ class LinstorVDI(VDI.VDI):
         # TODO: Check size after delete.
         self.sr._update_stats(-self.size)
         self.sr._kick_gc()
-        return super(LinstorVDI, self).delete(sr_uuid, vdi_uuid, data_only)
+        super(LinstorVDI, self).delete(sr_uuid, vdi_uuid, data_only)
+        self.sr._make_backupdb("delete")
 
     @override
     def attach(self, sr_uuid, vdi_uuid) -> str:
@@ -2375,7 +2423,9 @@ class LinstorVDI(VDI.VDI):
         if not blktap2.VDI.tap_pause(self.session, sr_uuid, vdi_uuid):
             raise util.SMException('Failed to pause VDI {}'.format(vdi_uuid))
         try:
-            return self._snapshot(snapType, cbtlog, consistency_state)
+            r = self._snapshot(snapType, cbtlog, consistency_state)
+            self.sr._make_backupdb("snapshot")
+            return r
         finally:
             self.disable_leaf_on_secondary(vdi_uuid, secondary=secondary)
             blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -811,7 +811,7 @@ class LinstorSR(SR.SR):
 
     @override
     def check_sr(self, sr_uuid) -> None:
-        self.backupdb("auto", delay=3600)
+        self.database_backup("auto", delay=3600)
 
 
     @override
@@ -1563,10 +1563,10 @@ class LinstorSR(SR.SR):
         util.SMlog('Kicking GC')
         cleanup.start_gc_service(self.uuid)
 
-    def backupdb(self, name, delay=0):
+    def database_backup(self, name="", *, delay=0):
         if not self._linstor:
             self._reconnect()
-        self._linstor.backupdb(name, delay)
+        self._linstor.database_backup(name, delay=delay)
 
 # ==============================================================================
 # LinstorSr VDI
@@ -1767,7 +1767,7 @@ class LinstorVDI(VDI.VDI):
         self.ref = self._db_introduce()
         self.sr._update_stats(self.size)
 
-        self.sr.backupdb("create")
+        self.sr.database_backup("create")
 
         return VDI.VDI.get_params(self)
 
@@ -1817,7 +1817,7 @@ class LinstorVDI(VDI.VDI):
         self.sr._update_stats(-self.size)
         self.sr._kick_gc()
         super(LinstorVDI, self).delete(sr_uuid, vdi_uuid, data_only)
-        self.sr.backupdb("delete")
+        self.sr.database_backup("delete")
 
     @override
     def attach(self, sr_uuid, vdi_uuid) -> str:
@@ -2388,9 +2388,9 @@ class LinstorVDI(VDI.VDI):
         if not blktap2.VDI.tap_pause(self.session, sr_uuid, vdi_uuid):
             raise util.SMException('Failed to pause VDI {}'.format(vdi_uuid))
         try:
-            r = self._snapshot(snapType, cbtlog, consistency_state)
-            self.sr.backupdb("snapshot")
-            return r
+            result = self._snapshot(snapType, cbtlog, consistency_state)
+            self.sr.database_backup("snapshot")
+            return result
         finally:
             self.disable_leaf_on_secondary(vdi_uuid, secondary=secondary)
             blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -2388,12 +2388,11 @@ class LinstorVDI(VDI.VDI):
         if not blktap2.VDI.tap_pause(self.session, sr_uuid, vdi_uuid):
             raise util.SMException('Failed to pause VDI {}'.format(vdi_uuid))
         try:
-            result = self._snapshot(snapType, cbtlog, consistency_state)
-            self.sr.database_backup("snapshot")
-            return result
+            return self._snapshot(snapType, cbtlog, consistency_state)
         finally:
             self.disable_leaf_on_secondary(vdi_uuid, secondary=secondary)
             blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)
+            self.sr.database_backup("snapshot")
 
     def _snapshot(self, snap_type, cbtlog=None, cbt_consistency=None):
         util.SMlog(

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -316,9 +316,9 @@ class LinstorVolumeManager(object):
 
     # linstordb backup parameters
     BACKUPDB_PATH = Path("/var/lib/linstor")
-    BACKUPDB_PATH_FORMAT = str(BACKUPDB_PATH / "{}.zip")
+    BACKUPDB_SECONDARY_PATH = Path("/var/lib/linstor.d/db-backups")
     BACKUPDB_NAME_FORMAT = "backupdb-{}-{}"
-    BACKUPDB_PATH_LATEST = BACKUPDB_PATH / "backupdb-latest.zip"
+    BACKUPDB_NAME_LATEST = "backupdb-latest.zip"
     BACKUPDB_RETENTION = 10
     BACKUPDB_DATE_FORMAT = "%Y%m%d_%H%M%S"
     BACKUPDB_DATE_GLOB = "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]"
@@ -1783,15 +1783,22 @@ class LinstorVolumeManager(object):
         # Create new backup with link to latest
         backupdb_name = self.BACKUPDB_NAME_FORMAT.format(now.strftime(self.BACKUPDB_DATE_FORMAT), name)
         self._linstor.controller_backupdb(backupdb_name)
+        backup_file = (self.BACKUPDB_PATH / backupdb_name).with_suffix(".zip")
+        # Copy to secondary backup location
         with contextlib.suppress(OSError):
-            self.BACKUPDB_PATH_LATEST.unlink()
-            self.BACKUPDB_PATH_LATEST.hardlink_to((self.BACKUPDB_PATH / backupdb_name).with_suffix(".zip"))
+            os.makedirs(self.BACKUPDB_SECONDARY_PATH, mode=0o755, exist_ok=True)
+            shutil.copy2(backup_file, self.BACKUPDB_SECONDARY_PATH)
+        for path in (self.BACKUPDB_PATH, self.BACKUPDB_SECONDARY_PATH):
+            with contextlib.suppress(OSError):
+                (path / self.BACKUPDB_NAME_LATEST).unlink()
+            os.link(str((path / backupdb_name).with_suffix(".zip")),
+                    str((path / self.BACKUPDB_NAME_LATEST)))
+            # Apply retention for named backups
+            for old_backupdb_file, _ in self._sorted_backupdb_list(path)[self.BACKUPDB_RETENTION:]:
+                os.unlink(old_backupdb_file)
+                # util.SMlog("[backupdb] Retention policy, removed: {}".format(old_backupdb_file.name))
         util.SMlog("[backupdb] Created: {}".format(backupdb_name))
 
-        # And keep only 10 named backups
-        for old_backupdb_file, _ in self._sorted_backupdb_list()[self.BACKUPDB_RETENTION:]:
-            os.unlink(old_backupdb_file)
-            util.SMlog("[backupdb] Retention policy, removed: {}".format(old_backupdb_file.name))
 
     @classmethod
     def get_all_group_names(cls, base_name):
@@ -2649,19 +2656,23 @@ class LinstorVolumeManager(object):
         properties.namespace = self._build_volume_namespace(volume_uuid)
         return properties
 
-    def _list_backupdb(self, name="*"):
-        for path in self.BACKUPDB_PATH.glob(self.BACKUPDB_NAME_FORMAT.format(
+    def _list_backupdb(self, backupdbpath, name="*"):
+        for path in backupdbpath.glob(self.BACKUPDB_NAME_FORMAT.format(
                 self.BACKUPDB_DATE_GLOB, name) + ".zip"):
             try:
                 yield path, datetime.strptime(path.name.split("-")[1], self.BACKUPDB_DATE_FORMAT)
             except (ValueError, IndexError):
                 continue
 
-    def _sorted_backupdb_list(self, name="*"):
-        return sorted(self._list_backupdb(name), reverse=True, key=lambda p: p[0].stat().st_mtime)
+    def _sorted_backupdb_list(self, path, name="*"):
+        return sorted(self._list_backupdb(path, name),
+                      reverse=True,
+                      key=lambda p: p[0].stat().st_mtime)
 
     def _latest_backupdb(self, name="*"):
-        return max(self._list_backupdb(name), default=None, key=lambda p: p[0].stat().st_mtime)
+        return max(self._list_backupdb(self.BACKUPDB_PATH, name),
+                   default=None,
+                   key=lambda p: p[0].stat().st_mtime)
 
     @classmethod
     def _build_sr_namespace(cls):

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -32,6 +32,9 @@ import stat
 import time
 import util
 import uuid
+from datetime import datetime
+from pathlib import Path
+import contextlib
 
 # Persistent prefix to add to RAW persistent volumes.
 PERSISTENT_PREFIX = 'xcp-persistent-'
@@ -310,6 +313,15 @@ class LinstorVolumeManager(object):
     # Limit request number when storage pool info is asked, we fetch
     # the current pool status after N elapsed seconds.
     STORAGE_POOLS_FETCH_INTERVAL = 15
+
+    # linstordb backup parameters
+    BACKUPDB_PATH = Path("/var/lib/linstor")
+    BACKUPDB_PATH_FORMAT = str(BACKUPDB_PATH / "{}.zip")
+    BACKUPDB_NAME_FORMAT = "backupdb-{}-{}"
+    BACKUPDB_PATH_LATEST = BACKUPDB_PATH / "backupdb-latest.zip"
+    BACKUPDB_RETENTION = 10
+    BACKUPDB_DATE_FORMAT = "%Y%m%d_%H%M%S"
+    BACKUPDB_DATE_GLOB = "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]"
 
     @staticmethod
     def default_logger(*args):
@@ -1758,6 +1770,29 @@ class LinstorVolumeManager(object):
         """
         return self._request_database_path(self._linstor, activate=True)
 
+    def backupdb(self, name, delay=0):
+        now = datetime.now()
+        # Throttling to avoid too many backups of the same kind on a short period
+        if delay:
+            latest_named_backupdb = self._latest_backupdb(name)
+            if latest_named_backupdb:
+                if (now - latest_named_backupdb[1]).total_seconds() < delay:
+                    util.SMlog("[backupdb] Throttling enabled: {}".format(latest_named_backupdb[0].name))
+                    return  # No backup for now
+
+        # Create new backup with link to latest
+        backupdb_name = self.BACKUPDB_NAME_FORMAT.format(now.strftime(self.BACKUPDB_DATE_FORMAT), name)
+        self._linstor.controller_backupdb(backupdb_name)
+        with contextlib.suppress(OSError):
+            self.BACKUPDB_PATH_LATEST.unlink()
+            self.BACKUPDB_PATH_LATEST.hardlink_to((self.BACKUPDB_PATH / backupdb_name).with_suffix(".zip"))
+        util.SMlog("[backupdb] Created: {}".format(backupdb_name))
+
+        # And keep only 10 named backups
+        for old_backupdb_file, _ in self._sorted_backupdb_list()[self.BACKUPDB_RETENTION:]:
+            os.unlink(old_backupdb_file)
+            util.SMlog("[backupdb] Retention policy, removed: {}".format(old_backupdb_file.name))
+
     @classmethod
     def get_all_group_names(cls, base_name):
         """
@@ -2613,6 +2648,20 @@ class LinstorVolumeManager(object):
         properties = self._get_kv_cache()
         properties.namespace = self._build_volume_namespace(volume_uuid)
         return properties
+
+    def _list_backupdb(self, name="*"):
+        for path in self.BACKUPDB_PATH.glob(self.BACKUPDB_NAME_FORMAT.format(
+                self.BACKUPDB_DATE_GLOB, name) + ".zip"):
+            try:
+                yield path, datetime.strptime(path.name.split("-")[1], self.BACKUPDB_DATE_FORMAT)
+            except (ValueError, IndexError):
+                continue
+
+    def _sorted_backupdb_list(self, name="*"):
+        return sorted(self._list_backupdb(name), reverse=True, key=lambda p: p[0].stat().st_mtime)
+
+    def _latest_backupdb(self, name="*"):
+        return max(self._list_backupdb(name), default=None, key=lambda p: p[0].stat().st_mtime)
 
     @classmethod
     def _build_sr_namespace(cls):

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -44,7 +44,12 @@ DATABASE_VOLUME_NAME = PERSISTENT_PREFIX + 'database'
 DATABASE_SIZE = 1 << 30  # 1GB.
 DATABASE_PATH = '/var/lib/linstor'
 DATABASE_MKFS = 'mkfs.ext4'
-
+DATABASE_BACKUP_PATH_MAIN = Path(DATABASE_PATH)
+DATABASE_BACKUP_PATH_SPARE = Path('/var/lib/linstor.d/db-backups')
+DATABASE_BACKUP_NAME_FORMAT = "linstor_database_backup-{}-{}"
+DATABASE_BACKUP_NAME_LATEST = "linstor_database_backup-latest.zip"
+DATABASE_BACKUP_RETENTION = 10
+DATABASE_BACKUP_DATE_FORMAT = "%Y%m%d_%H%M%S"
 LINSTOR_SATELLITE_PORT = 3366
 
 REG_DRBDADM_PRIMARY = re.compile("([^\\s]+)\\s+role:Primary")
@@ -313,15 +318,6 @@ class LinstorVolumeManager(object):
     # Limit request number when storage pool info is asked, we fetch
     # the current pool status after N elapsed seconds.
     STORAGE_POOLS_FETCH_INTERVAL = 15
-
-    # linstordb backup parameters
-    BACKUPDB_PATH = Path("/var/lib/linstor")
-    BACKUPDB_SECONDARY_PATH = Path("/var/lib/linstor.d/db-backups")
-    BACKUPDB_NAME_FORMAT = "backupdb-{}-{}"
-    BACKUPDB_NAME_LATEST = "backupdb-latest.zip"
-    BACKUPDB_RETENTION = 10
-    BACKUPDB_DATE_FORMAT = "%Y%m%d_%H%M%S"
-    BACKUPDB_DATE_GLOB = "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]"
 
     @staticmethod
     def default_logger(*args):
@@ -1770,35 +1766,34 @@ class LinstorVolumeManager(object):
         """
         return self._request_database_path(self._linstor, activate=True)
 
-    def backupdb(self, name, delay=0):
+    def database_backup(self, name="", *, delay=0):
         now = datetime.now()
         # Throttling to avoid too many backups of the same kind on a short period
         if delay:
-            latest_named_backupdb = self._latest_backupdb(name)
-            if latest_named_backupdb:
-                if (now - latest_named_backupdb[1]).total_seconds() < delay:
-                    util.SMlog("[backupdb] Throttling enabled: {}".format(latest_named_backupdb[0].name))
-                    return  # No backup for now
+            _, date_latest = self._get_latest_database_backup(name)
+            if date_latest and ((now - date_latest).total_seconds() < delay):
+                return  # No backup for now
 
         # Create new backup with link to latest
-        backupdb_name = self.BACKUPDB_NAME_FORMAT.format(now.strftime(self.BACKUPDB_DATE_FORMAT), name)
-        self._linstor.controller_backupdb(backupdb_name)
-        backup_file = (self.BACKUPDB_PATH / backupdb_name).with_suffix(".zip")
+        filename = DATABASE_BACKUP_NAME_FORMAT.format(now.strftime(DATABASE_BACKUP_DATE_FORMAT), name)
+        self._linstor.controller_backupdb(filename)
         # Copy to secondary backup location
         with contextlib.suppress(OSError):
-            os.makedirs(self.BACKUPDB_SECONDARY_PATH, mode=0o755, exist_ok=True)
-            shutil.copy2(backup_file, self.BACKUPDB_SECONDARY_PATH)
-        for path in (self.BACKUPDB_PATH, self.BACKUPDB_SECONDARY_PATH):
+            os.makedirs(DATABASE_BACKUP_PATH_SPARE, mode=0o755, exist_ok=True)
+            shutil.copy2(
+                (DATABASE_BACKUP_PATH_MAIN / filename).with_suffix(".zip"),
+                DATABASE_BACKUP_PATH_SPARE,
+            )
+        for path in (DATABASE_BACKUP_PATH_MAIN, DATABASE_BACKUP_PATH_SPARE):
+            # Remove and set latest
             with contextlib.suppress(OSError):
-                (path / self.BACKUPDB_NAME_LATEST).unlink()
-            os.link(str((path / backupdb_name).with_suffix(".zip")),
-                    str((path / self.BACKUPDB_NAME_LATEST)))
-            # Apply retention for named backups
-            for old_backupdb_file, _ in self._sorted_backupdb_list(path)[self.BACKUPDB_RETENTION:]:
-                os.unlink(old_backupdb_file)
-                # util.SMlog("[backupdb] Retention policy, removed: {}".format(old_backupdb_file.name))
-        util.SMlog("[backupdb] Created: {}".format(backupdb_name))
-
+                (path / DATABASE_BACKUP_NAME_LATEST).unlink()
+            os.link(str((path / filename).with_suffix(".zip")),
+                    str((path / DATABASE_BACKUP_NAME_LATEST)))
+            # Apply retention
+            for old_file, _ in self._get_sorted_database_backup(path)[DATABASE_BACKUP_RETENTION:]:
+                os.unlink(old_file)
+        util.SMlog("[database_backup] Created: {}".format(filename))
 
     @classmethod
     def get_all_group_names(cls, base_name):
@@ -2656,22 +2651,22 @@ class LinstorVolumeManager(object):
         properties.namespace = self._build_volume_namespace(volume_uuid)
         return properties
 
-    def _list_backupdb(self, backupdbpath, name="*"):
-        for path in backupdbpath.glob(self.BACKUPDB_NAME_FORMAT.format(
-                self.BACKUPDB_DATE_GLOB, name) + ".zip"):
+    def _list_database_backup(self, dbpath, name="*"):
+        for path in dbpath.glob(DATABASE_BACKUP_NAME_FORMAT.format(
+                "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]", name) + ".zip"):
             try:
-                yield path, datetime.strptime(path.name.split("-")[1], self.BACKUPDB_DATE_FORMAT)
+                yield path, datetime.strptime(path.name.split("-")[1], DATABASE_BACKUP_DATE_FORMAT)
             except (ValueError, IndexError):
                 continue
 
-    def _sorted_backupdb_list(self, path, name="*"):
-        return sorted(self._list_backupdb(path, name),
+    def _get_sorted_database_backup(self, dbpath, name="*"):
+        return sorted(self._list_database_backup(dbpath, name),
                       reverse=True,
                       key=lambda p: p[0].stat().st_mtime)
 
-    def _latest_backupdb(self, name="*"):
-        return max(self._list_backupdb(self.BACKUPDB_PATH, name),
-                   default=None,
+    def _get_latest_database_backup(self, name="*"):
+        return max(self._list_database_backup(DATABASE_BACKUP_PATH_MAIN, name),
+                   default=(None, None),
                    key=lambda p: p[0].stat().st_mtime)
 
     @classmethod

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -44,8 +44,8 @@ DATABASE_VOLUME_NAME = PERSISTENT_PREFIX + 'database'
 DATABASE_SIZE = 1 << 30  # 1GB.
 DATABASE_PATH = '/var/lib/linstor'
 DATABASE_MKFS = 'mkfs.ext4'
-DATABASE_BACKUP_PATH_MAIN = Path(DATABASE_PATH)
-DATABASE_BACKUP_PATH_SPARE = Path('/var/lib/linstor.d/db-backups')
+DATABASE_BACKUP_DIR_MAIN = Path(DATABASE_PATH)
+DATABASE_BACKUP_DIR_SPARE = Path('/var/lib/linstor.d/db-backups')
 DATABASE_BACKUP_NAME_FORMAT = "linstor_database_backup-{}-{}"
 DATABASE_BACKUP_NAME_LATEST = "linstor_database_backup-latest.zip"
 DATABASE_BACKUP_RETENTION = 10
@@ -1779,19 +1779,19 @@ class LinstorVolumeManager(object):
         self._linstor.controller_backupdb(filename)
         # Copy to secondary backup location
         with contextlib.suppress(OSError):
-            os.makedirs(DATABASE_BACKUP_PATH_SPARE, mode=0o755, exist_ok=True)
+            os.makedirs(DATABASE_BACKUP_DIR_SPARE, mode=0o755, exist_ok=True)
             shutil.copy2(
-                (DATABASE_BACKUP_PATH_MAIN / filename).with_suffix(".zip"),
-                DATABASE_BACKUP_PATH_SPARE,
+                (DATABASE_BACKUP_DIR_MAIN / filename).with_suffix(".zip"),
+                DATABASE_BACKUP_DIR_SPARE,
             )
-        for path in (DATABASE_BACKUP_PATH_MAIN, DATABASE_BACKUP_PATH_SPARE):
+        for directory in (DATABASE_BACKUP_DIR_MAIN, DATABASE_BACKUP_DIR_SPARE):
             # Remove and set latest
             with contextlib.suppress(OSError):
-                (path / DATABASE_BACKUP_NAME_LATEST).unlink()
-            os.link(str((path / filename).with_suffix(".zip")),
-                    str((path / DATABASE_BACKUP_NAME_LATEST)))
+                (directory / DATABASE_BACKUP_NAME_LATEST).unlink()
+            os.link(str((directory / filename).with_suffix(".zip")),
+                    str((directory / DATABASE_BACKUP_NAME_LATEST)))
             # Apply retention
-            for old_file, _ in self._get_sorted_database_backup(path)[DATABASE_BACKUP_RETENTION:]:
+            for old_file, _ in self._get_sorted_database_backup(directory)[DATABASE_BACKUP_RETENTION:]:
                 os.unlink(old_file)
         util.SMlog("[database_backup] Created: {}".format(filename))
 
@@ -2651,21 +2651,21 @@ class LinstorVolumeManager(object):
         properties.namespace = self._build_volume_namespace(volume_uuid)
         return properties
 
-    def _list_database_backup(self, dbpath, name="*"):
-        for path in dbpath.glob(DATABASE_BACKUP_NAME_FORMAT.format(
+    def _list_database_backup(self, database_backup_dir, name="*"):
+        for path in database_backup_dir.glob(DATABASE_BACKUP_NAME_FORMAT.format(
                 "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]", name) + ".zip"):
             try:
                 yield path, datetime.strptime(path.name.split("-")[1], DATABASE_BACKUP_DATE_FORMAT)
             except (ValueError, IndexError):
                 continue
 
-    def _get_sorted_database_backup(self, dbpath, name="*"):
-        return sorted(self._list_database_backup(dbpath, name),
+    def _get_sorted_database_backup(self, database_backup_dir, name="*"):
+        return sorted(self._list_database_backup(database_backup_dir, name),
                       reverse=True,
                       key=lambda p: p[0].stat().st_mtime)
 
     def _get_latest_database_backup(self, name="*"):
-        return max(self._list_database_backup(DATABASE_BACKUP_PATH_MAIN, name),
+        return max(self._list_database_backup(DATABASE_BACKUP_DIR_MAIN, name),
                    default=(None, None),
                    key=lambda p: p[0].stat().st_mtime)
 


### PR DESCRIPTION
Backup on VDI create, delete and snapshot, and regularly on check_sr.
Latest backup is linked (hard link as /usr/lib/linstor is in ext4) on a backupdb-latest.zip file.
Retention of 10 backups, older are removed.