### PR TITLE
Regroup all session creation in util get_localAPI_session or APISession class.

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -2585,7 +2585,7 @@ class LinstorVDI(VDI.VDI):
                 # Use a timeout call because XAPI may be unusable on startup
                 # or if the host has been ejected. So in this case the call can
                 # block indefinitely.
-                api_session = util.timeout(5, util.APISession, "SM-ha-linstor-http-server")
+                api_session = util.timeout(5, util.ApiSession, "SM-ha-linstor-http-server")
                 session = api_session.session
                 host_ip = util.get_this_host_address(session)
             except:
@@ -2672,7 +2672,7 @@ class LinstorVDI(VDI.VDI):
                 device_size = 256 * 1024 * 1024
 
             try:
-                api_session = util.timeout(5, util.APISession, "SM-ha-linstor-nbd-server")
+                api_session = util.timeout(5, util.ApiSession, "SM-ha-linstor-nbd-server")
                 session = api_session.session
                 ips = util.get_host_addresses(session)
             except Exception as e:

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -2585,9 +2585,8 @@ class LinstorVDI(VDI.VDI):
                 # Use a timeout call because XAPI may be unusable on startup
                 # or if the host has been ejected. So in this case the call can
                 # block indefinitely.
-                apisession = util.timeout(
-                    5, util.APISession, "SM-LinstorSR-http")
-                session = apisession.session
+                api_session = util.timeout(5, util.APISession, "SM-ha-linstor-http-server")
+                session = api_session.session
                 host_ip = util.get_this_host_address(session)
             except:
                 # Fallback using the XHA file if session not available.
@@ -2596,6 +2595,8 @@ class LinstorVDI(VDI.VDI):
                     raise Exception(
                         'Cannot start persistent HTTP server: no XAPI session, nor XHA config file'
                     )
+            finally:
+                api_session.logout()
 
             arguments = [
                 'http-disk-server',
@@ -2671,9 +2672,8 @@ class LinstorVDI(VDI.VDI):
                 device_size = 256 * 1024 * 1024
 
             try:
-                apisession = util.timeout(
-                    5, util.APISession, "SM-LinstorSR-nbd")
-                session = apisession.session
+                api_session = util.timeout(5, util.APISession, "SM-ha-linstor-nbd-server")
+                session = api_session.session
                 ips = util.get_host_addresses(session)
             except Exception as e:
                 _, ips = get_ips_from_xha_config_file()
@@ -2682,6 +2682,8 @@ class LinstorVDI(VDI.VDI):
                         'Cannot start persistent NBD server: no XAPI session, nor XHA config file ({})'.format(e)
                     )
                 ips = ips.values()
+            finally:
+                api_session.logout()
 
             arguments = [
                 'nbd-http-server',

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -2585,7 +2585,9 @@ class LinstorVDI(VDI.VDI):
                 # Use a timeout call because XAPI may be unusable on startup
                 # or if the host has been ejected. So in this case the call can
                 # block indefinitely.
-                session = util.timeout(5, util.get_localAPI_session)
+                apisession = util.timeout(
+                    5, util.APISession, "SM-LinstorSR-http")
+                session = apisession.session
                 host_ip = util.get_this_host_address(session)
             except:
                 # Fallback using the XHA file if session not available.
@@ -2669,7 +2671,9 @@ class LinstorVDI(VDI.VDI):
                 device_size = 256 * 1024 * 1024
 
             try:
-                session = util.timeout(5, util.get_localAPI_session)
+                apisession = util.timeout(
+                    5, util.APISession, "SM-LinstorSR-nbd")
+                session = apisession.session
                 ips = util.get_host_addresses(session)
             except Exception as e:
                 _, ips = get_ips_from_xha_config_file()

--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -521,7 +521,7 @@
 
        <!-- Agent database query errors 150+ -->
         <code>
-                <name>ApiSession</name>
+                <name>APISession</name>
                 <description>Failed to initialize XMLRPC connection</description>
                 <value>150</value>
         </code>

--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -521,7 +521,7 @@
 
        <!-- Agent database query errors 150+ -->
         <code>
-                <name>APISession</name>
+                <name>ApiSession</name>
                 <description>Failed to initialize XMLRPC connection</description>
                 <value>150</value>
         </code>

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -881,7 +881,8 @@ class Tapdisk(object):
 
         openers = get_all_volume_openers(volume_name, "0")
 
-        session = util.timeout(5, util.get_localAPI_session)
+        api_session = util.timeout(5, util.APISession, "blktap-abort_linstor_gc")
+        session = api_session.session
         try:
             srs = util.get_linstor_srs_uuid(session)
             pbd_ref = util.find_pbd_ref_from_dconf_value(
@@ -901,7 +902,7 @@ class Tapdisk(object):
 
             util.SMlog(f"Unable to run tapdisk, openers of DRBD resource `{drbd_path}`: {openers}")
         finally:
-            session.xenapi.session.logout()
+            api_session.logout()
 
         return False
 

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -881,18 +881,18 @@ class Tapdisk(object):
 
         openers = get_all_volume_openers(volume_name, "0")
 
-        api_session = util.timeout(5, util.APISession, "blktap-abort_linstor_gc")
-        session = api_session.session
+        api_session = util.timeout(5, util.APISession, "SM-blktap2-abort_linstor_gc")
         try:
-            srs = util.get_linstor_srs_uuid(session)
+            srs = util.get_linstor_srs_uuid(api_session.session)
             pbd_ref = util.find_pbd_ref_from_dconf_value(
-                session, srs, "group-name", group_name, LinstorVolumeManager.build_group_name
+                api_session.session, srs, "group-name", group_name,
+                LinstorVolumeManager.build_group_name,
             )
             if pbd_ref:
-                pbd_rec = session.xenapi.PBD.get_record(pbd_ref)
+                pbd_rec = api_session.session.xenapi.PBD.get_record(pbd_ref)
 
                 sr_ref = pbd_rec["SR"]
-                sr_uuid = session.xenapi.SR.get_uuid(sr_ref)
+                sr_uuid = api_session.session.xenapi.SR.get_uuid(sr_ref)
 
                 import cleanup # pylint: disable=C0415
                 if cleanup.LinstorSR.abort_gc_from_openers_sr(sr_uuid, openers):

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -881,7 +881,7 @@ class Tapdisk(object):
 
         openers = get_all_volume_openers(volume_name, "0")
 
-        api_session = util.timeout(5, util.ApiSession, "SM-blktap2-abort_linstor_gc")
+        api_session = util.timeout(5, util.ApiSession, "SM-blktap2-abort-linstor-gc")
         try:
             srs = util.get_linstor_srs_uuid(api_session.session)
             pbd_ref = util.find_pbd_ref_from_dconf_value(

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -881,7 +881,7 @@ class Tapdisk(object):
 
         openers = get_all_volume_openers(volume_name, "0")
 
-        api_session = util.timeout(5, util.APISession, "SM-blktap2-abort_linstor_gc")
+        api_session = util.timeout(5, util.ApiSession, "SM-blktap2-abort_linstor_gc")
         try:
             srs = util.get_linstor_srs_uuid(api_session.session)
             pbd_ref = util.find_pbd_ref_from_dconf_value(
@@ -1153,7 +1153,7 @@ class VDI(object):
 
     @classmethod
     def from_cli(cls, uuid):
-        with util.APISession("SM-blktap2") as session:
+        with util.ApiSession("SM-blktap2") as session:
             target = sm.VDI.from_uuid(session, uuid)
             driver_info = target.sr.srcmd.driver_info
         return cls(uuid, target, driver_info)

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1152,14 +1152,9 @@ class VDI(object):
 
     @classmethod
     def from_cli(cls, uuid):
-        session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '', '', 'SM')
-
-        target = sm.VDI.from_uuid(session, uuid)
-        driver_info = target.sr.srcmd.driver_info
-
-        session.xenapi.session.logout()
-
+        with util.APISession("SM-blktap2") as session:
+            target = sm.VDI.from_uuid(session, uuid)
+            driver_info = target.sr.srcmd.driver_info
         return cls(uuid, target, driver_info)
 
     @staticmethod

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -303,7 +303,7 @@ class XAPI:
         self.session = session
         self._api_session = None
         if self.session is None:
-            self._api_session = util.APISession("SM-cleanup-XAPI")
+            self._api_session = util.APISession("SM-GC")
             self.session = self._api_session.session
         self._srRef = self.session.xenapi.SR.get_by_uuid(srUuid)
         self.srRecord = self.session.xenapi.SR.get_record(self._srRef)
@@ -2121,7 +2121,7 @@ class SR(object):
         return msg is None
 
     def check_no_space_candidates(self):
-        with util.APISession("GC-check_no_space") as xapi_session:
+        with util.APISession("SM-GC-check_no_space") as xapi_session:
             msg_id = self.xapi.srRecord["sm_config"].get(VDI.DB_GC_NO_SPACE)
             if self.no_space_candidates:
                 if msg_id is None or self.msg_cleared(xapi_session, msg_id):
@@ -3928,7 +3928,7 @@ class LinstorSR(SR):
                 if node_name == hostname:
                     continue
 
-                with util.timeout(5), util.APISession("GC-coalescing") as session:
+                with util.timeout(5), util.APISession("SM-GC-coalescing") as session:
                     sr_uuid = util.get_sr_uuid_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
                     util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
                     return util.strtobool(session.xenapi.host.call_plugin(

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -3928,16 +3928,12 @@ class LinstorSR(SR):
                 if node_name == hostname:
                     continue
 
-                with util.timeout(5):
-                    session = XAPI.getSession()
-                    try:
-                        sr_uuid = util.get_sr_uuid_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
-                        util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
-                        return util.strtobool(session.xenapi.host.call_plugin(
-                            util.get_master_ref(session), MANAGER_PLUGIN, "abortGc", {"srUuid": sr_uuid}
-                        ))
-                    finally:
-                        session.xenapi.session.logout()
+                with util.timeout(5), util.APISession("GC-coalescing") as session:
+                    sr_uuid = util.get_sr_uuid_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
+                    util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
+                    return util.strtobool(session.xenapi.host.call_plugin(
+                        util.get_master_ref(session), MANAGER_PLUGIN, "abortGc", {"srUuid": sr_uuid}
+                    ))
         return False
 
 

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -301,10 +301,10 @@ class XAPI:
 
     def __init__(self, session, srUuid):
         self.session = session
-        self.apisession = None
+        self._api_session = None
         if self.session is None:
-            self.apisession = util.APISession("SM-cleanup-XAPI")
-            self.session = self.apisession.session
+            self._api_session = util.APISession("SM-cleanup-XAPI")
+            self.session = self._api_session.session
         self._srRef = self.session.xenapi.SR.get_by_uuid(srUuid)
         self.srRecord = self.session.xenapi.SR.get_record(self._srRef)
         self.hostUuid = util.get_this_host()
@@ -313,8 +313,8 @@ class XAPI:
         self.task_progress = {"coalescable": 0, "done": 0}
 
     def __del__(self):
-        if self.apisession:
-            self.apisession.logout()
+        if self._api_session:
+            self._api_session.logout()
 
     @property
     def srRef(self):
@@ -2121,7 +2121,7 @@ class SR(object):
         return msg is None
 
     def check_no_space_candidates(self):
-        with util.APISession("SM-cleanup-SR-check_no_space_candidates") as xapi_session:
+        with util.APISession("GC-check_no_space") as xapi_session:
             msg_id = self.xapi.srRecord["sm_config"].get(VDI.DB_GC_NO_SPACE)
             if self.no_space_candidates:
                 if msg_id is None or self.msg_cleared(xapi_session, msg_id):

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -303,7 +303,7 @@ class XAPI:
         self.session = session
         self._api_session = None
         if self.session is None:
-            self._api_session = util.APISession("SM-GC")
+            self._api_session = util.ApiSession("SM-GC")
             self.session = self._api_session.session
         self._srRef = self.session.xenapi.SR.get_by_uuid(srUuid)
         self.srRecord = self.session.xenapi.SR.get_record(self._srRef)
@@ -2121,7 +2121,7 @@ class SR(object):
         return msg is None
 
     def check_no_space_candidates(self):
-        with util.APISession("SM-GC-check_no_space") as xapi_session:
+        with util.ApiSession("SM-GC-check_no_space") as xapi_session:
             msg_id = self.xapi.srRecord["sm_config"].get(VDI.DB_GC_NO_SPACE)
             if self.no_space_candidates:
                 if msg_id is None or self.msg_cleared(xapi_session, msg_id):
@@ -3928,7 +3928,7 @@ class LinstorSR(SR):
                 if node_name == hostname:
                     continue
 
-                with util.timeout(5), util.APISession("SM-GC-coalescing") as session:
+                with util.timeout(5), util.ApiSession("SM-GC-coalescing") as session:
                     sr_uuid = util.get_sr_uuid_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
                     util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
                     return util.strtobool(session.xenapi.host.call_plugin(

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -303,7 +303,7 @@ class XAPI:
         self.session = session
         self._api_session = None
         if self.session is None:
-            self._api_session = util.ApiSession("SM-GC")
+            self._api_session = util.ApiSession("SMGC")
             self.session = self._api_session.session
         self._srRef = self.session.xenapi.SR.get_by_uuid(srUuid)
         self.srRecord = self.session.xenapi.SR.get_record(self._srRef)
@@ -2121,7 +2121,7 @@ class SR(object):
         return msg is None
 
     def check_no_space_candidates(self):
-        with util.ApiSession("SM-GC-check_no_space") as xapi_session:
+        with util.ApiSession("SMGC-check-no-space") as xapi_session:
             msg_id = self.xapi.srRecord["sm_config"].get(VDI.DB_GC_NO_SPACE)
             if self.no_space_candidates:
                 if msg_id is None or self.msg_cleared(xapi_session, msg_id):
@@ -3928,7 +3928,7 @@ class LinstorSR(SR):
                 if node_name == hostname:
                     continue
 
-                with util.timeout(5), util.ApiSession("SM-GC-coalescing") as session:
+                with util.timeout(5), util.ApiSession("SMGC-coalescing") as session:
                     sr_uuid = util.get_sr_uuid_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
                     util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
                     return util.strtobool(session.xenapi.host.call_plugin(

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -299,18 +299,12 @@ class XAPI:
     class LookupError(util.SMException):
         pass
 
-    @staticmethod
-    def getSession():
-        session = XenAPI.xapi_local()
-        session.xenapi.login_with_password(XAPI.USER, '', '', 'SM')
-        return session
-
     def __init__(self, session, srUuid):
-        self.sessionPrivate = False
         self.session = session
+        self.apisession = None
         if self.session is None:
-            self.session = self.getSession()
-            self.sessionPrivate = True
+            self.apisession = util.APISession("SM-cleanup-XAPI")
+            self.session = self.apisession.session
         self._srRef = self.session.xenapi.SR.get_by_uuid(srUuid)
         self.srRecord = self.session.xenapi.SR.get_record(self._srRef)
         self.hostUuid = util.get_this_host()
@@ -319,8 +313,8 @@ class XAPI:
         self.task_progress = {"coalescable": 0, "done": 0}
 
     def __del__(self):
-        if self.sessionPrivate:
-            self.session.xenapi.session.logout()
+        if self.apisession:
+            self.apisession.logout()
 
     @property
     def srRef(self):
@@ -2127,32 +2121,31 @@ class SR(object):
         return msg is None
 
     def check_no_space_candidates(self):
-        xapi_session = self.xapi.getSession()
+        with util.APISession("SM-cleanup-SR-check_no_space_candidates") as xapi_session:
+            msg_id = self.xapi.srRecord["sm_config"].get(VDI.DB_GC_NO_SPACE)
+            if self.no_space_candidates:
+                if msg_id is None or self.msg_cleared(xapi_session, msg_id):
+                    util.SMlog("Could not coalesce due to a lack of space "
+                               f"in SR {self.uuid}")
+                    msg_body = ("Unable to perform data coalesce due to a lack "
+                                f"of space in SR {self.uuid}")
+                    msg_id = xapi_session.xenapi.message.create(
+                        'SM_GC_NO_SPACE',
+                        3,
+                        "SR",
+                        self.uuid,
+                        msg_body)
+                    xapi_session.xenapi.SR.remove_from_sm_config(
+                        self.xapi.srRef, VDI.DB_GC_NO_SPACE)
+                    xapi_session.xenapi.SR.add_to_sm_config(
+                        self.xapi.srRef, VDI.DB_GC_NO_SPACE, msg_id)
 
-        msg_id = self.xapi.srRecord["sm_config"].get(VDI.DB_GC_NO_SPACE)
-        if self.no_space_candidates:
-            if msg_id is None or self.msg_cleared(xapi_session, msg_id):
-                util.SMlog("Could not coalesce due to a lack of space "
-                           f"in SR {self.uuid}")
-                msg_body = ("Unable to perform data coalesce due to a lack "
-                            f"of space in SR {self.uuid}")
-                msg_id = xapi_session.xenapi.message.create(
-                    'SM_GC_NO_SPACE',
-                    3,
-                    "SR",
-                    self.uuid,
-                    msg_body)
-                xapi_session.xenapi.SR.remove_from_sm_config(
-                    self.xapi.srRef, VDI.DB_GC_NO_SPACE)
-                xapi_session.xenapi.SR.add_to_sm_config(
-                    self.xapi.srRef, VDI.DB_GC_NO_SPACE, msg_id)
-
-            for candidate in self.no_space_candidates.values():
-                candidate.setConfig(VDI.DB_GC_NO_SPACE, msg_id)
-        elif msg_id is not None:
-            # Everything was coalescable, remove the message
-            xapi_session.xenapi.SR.remove_from_sm_config(self.xapi.srRef, VDI.DB_GC_NO_SPACE)
-            xapi_session.xenapi.message.destroy(msg_id)
+                for candidate in self.no_space_candidates.values():
+                    candidate.setConfig(VDI.DB_GC_NO_SPACE, msg_id)
+            elif msg_id is not None:
+                # Everything was coalescable, remove the message
+                xapi_session.xenapi.SR.remove_from_sm_config(self.xapi.srRef, VDI.DB_GC_NO_SPACE)
+                xapi_session.xenapi.message.destroy(msg_id)
 
     def clear_no_space_msg(self, vdi):
         msg_id = None

--- a/drivers/coalesce-leaf
+++ b/drivers/coalesce-leaf
@@ -2,13 +2,13 @@
 #
 # Copyright (C) Citrix Systems Inc.
 #
-# This program is free software; you can redistribute it and/or modify 
-# it under the terms of the GNU Lesser General Public License as published 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
 # by the Free Software Foundation; version 2.1 only.
 #
-# This program is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
@@ -229,12 +229,9 @@ def main():
         print(USAGE_STRING % sys.argv[0])
         sys.exit(-1)
 
-    session = XenAPI.xapi_local()
-    session.xenapi.login_with_password('root', '', '', 'SM')
-    atexit.register(session.xenapi.session.logout)
-
-    ret, messages = vm_leaf_coalesce(session, uuid)
-    if len(messages):
+    with util.APISession("SM-coalesce-leaf") as session:
+        ret, messages = vm_leaf_coalesce(session, uuid)
+    if messages:
         print("\n".join(messages))
     sys.exit(ret)
 

--- a/drivers/coalesce-leaf
+++ b/drivers/coalesce-leaf
@@ -2,8 +2,8 @@
 #
 # Copyright (C) Citrix Systems Inc.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published
+# This program is free software; you can redistribute it and/or modify 
+# it under the terms of the GNU Lesser General Public License as published 
 # by the Free Software Foundation; version 2.1 only.
 #
 # This program is distributed in the hope that it will be useful, 

--- a/drivers/coalesce-leaf
+++ b/drivers/coalesce-leaf
@@ -6,9 +6,9 @@
 # it under the terms of the GNU Lesser General Public License as published
 # by the Free Software Foundation; version 2.1 only.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of 
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License

--- a/drivers/coalesce-leaf
+++ b/drivers/coalesce-leaf
@@ -229,7 +229,7 @@ def main():
         print(USAGE_STRING % sys.argv[0])
         sys.exit(-1)
 
-    with util.APISession("SM-coalesce-leaf") as session:
+    with util.ApiSession("SM-coalesce-leaf") as session:
         ret, messages = vm_leaf_coalesce(session, uuid)
     if messages:
         print("\n".join(messages))

--- a/drivers/lcache.py
+++ b/drivers/lcache.py
@@ -221,12 +221,9 @@ class CacheFileSR(object):
 
     @classmethod
     def from_cli(cls):
-        import XenAPI # pylint: disable=import-error
-
-        session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '', '', 'SM')
-
-        return cls.from_session(session)
+        import util
+        with util.APISession("SM-lcache-CacheFileSR") as session:
+            return cls.from_session(session)
 
     def statvfs(self):
         return os.statvfs(self.sr_path)

--- a/drivers/lcache.py
+++ b/drivers/lcache.py
@@ -221,7 +221,7 @@ class CacheFileSR(object):
 
     @classmethod
     def from_cli(cls):
-        with util.APISession("SM-local-cache") as session:
+        with util.ApiSession("SM-local-cache") as session:
             return cls.from_session(session)
 
     def statvfs(self):

--- a/drivers/lcache.py
+++ b/drivers/lcache.py
@@ -221,7 +221,7 @@ class CacheFileSR(object):
 
     @classmethod
     def from_cli(cls):
-        with util.APISession("SM-lcache-CacheFileSR") as session:
+        with util.APISession("SM-local-cache") as session:
             return cls.from_session(session)
 
     def statvfs(self):

--- a/drivers/lcache.py
+++ b/drivers/lcache.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+import util
 from sm_typing import override
 
 import os
@@ -199,7 +200,6 @@ class CacheFileSR(object):
 
     @classmethod
     def from_session(cls, session):
-        import util
         import SR as sm
 
         host_ref = util.get_localhost_ref(session)
@@ -221,7 +221,6 @@ class CacheFileSR(object):
 
     @classmethod
     def from_cli(cls):
-        import util
         with util.APISession("SM-lcache-CacheFileSR") as session:
             return cls.from_session(session)
 
@@ -236,8 +235,6 @@ class CacheFileSR(object):
         return list(found)
 
     def xapi_vfs_stats(self):
-        import util
-
         f = self.statvfs()
         if not f.f_frsize:
             raise util.SMException("Cache FS does not report utilization.")

--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -678,7 +678,7 @@ class MultiLinstorCowUtil:
         return instance
 
     def _init_executor_thread(self):
-        api_session = util.ApiSession("SM-linstorvhdutil")
+        api_session = util.ApiSession("SM-linstor-multi-cow-util")
         try:
             linstor = LinstorVolumeManager(
                 self._uri,

--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -651,7 +651,7 @@ class MultiLinstorCowUtil:
     def __init__(self, uri, group_name) -> None:
         self._uri = uri
         self._group_name = group_name
-        self._loads: List[util.APISession] = []
+        self._loads: List[util.ApiSession] = []
         self._executor_data = self.ExecutorData()
 
     def __del__(self):
@@ -678,7 +678,7 @@ class MultiLinstorCowUtil:
         return instance
 
     def _init_executor_thread(self):
-        api_session = util.APISession("SM-linstorvhdutil")
+        api_session = util.ApiSession("SM-linstorvhdutil")
         try:
             linstor = LinstorVolumeManager(
                 self._uri,

--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -678,8 +678,8 @@ class MultiLinstorCowUtil:
         return instance
 
     def _init_executor_thread(self):
-        apisession = util.APISession("SM-linstorvhdutil")
-        session = apisession.session
+        api_session = util.APISession("SM-linstorvhdutil")
+        session = api_session.session
         try:
             linstor = LinstorVolumeManager(
                 self._uri,
@@ -692,7 +692,7 @@ class MultiLinstorCowUtil:
         except:
             self._executor_data.clear()
             raise
-        self._loads.append(apisession)
+        self._loads.append(api_session)
 
     def _cleanup(self):
         for load in self._loads:

--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -648,19 +648,10 @@ class MultiLinstorCowUtil:
             self.linstor = None
             self.vdi_type_to_cowutil = {}
 
-    class Load:
-        def __init__(self, session):
-            self.session = session
-
-        def cleanup(self):
-            if self.session:
-                self.session.xenapi.session.logout()
-                self.session = None
-
     def __init__(self, uri, group_name) -> None:
         self._uri = uri
         self._group_name = group_name
-        self._loads: List[MultiLinstorCowUtil.Load] = []
+        self._loads: List[util.APISession] = []
         self._executor_data = self.ExecutorData()
 
     def __del__(self):
@@ -687,8 +678,8 @@ class MultiLinstorCowUtil:
         return instance
 
     def _init_executor_thread(self):
-        session = util.get_localAPI_session()
-        load = self.Load(session)
+        apisession = util.APISession("SM-linstorvhdutil")
+        session = apisession.session
         try:
             linstor = LinstorVolumeManager(
                 self._uri,
@@ -700,15 +691,13 @@ class MultiLinstorCowUtil:
             self._executor_data.session = session
         except:
             self._executor_data.clear()
-            load.cleanup()
             raise
-
-        self._loads.append(load)
+        self._loads.append(apisession)
 
     def _cleanup(self):
         for load in self._loads:
             try:
-                load.cleanup()
+                load.logout()
             except Exception as e:
                 util.SMlog(f"Failed to clean load executor: {e}")
         self._loads.clear()

--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -679,7 +679,6 @@ class MultiLinstorCowUtil:
 
     def _init_executor_thread(self):
         api_session = util.APISession("SM-linstorvhdutil")
-        session = api_session.session
         try:
             linstor = LinstorVolumeManager(
                 self._uri,
@@ -688,7 +687,7 @@ class MultiLinstorCowUtil:
                 logger=util.SMlog
             )
             self._executor_data.linstor = linstor
-            self._executor_data.session = session
+            self._executor_data.session = api_session.session
         except:
             self._executor_data.clear()
             raise

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -101,7 +101,7 @@ def get_all_volume_openers(resource_name, volume) -> LinstorVolumeOpeners:
     volume = str(volume)
     openers = {}
 
-    with util.APISession("SM-linstorvolumemanager-get_all_volume_openers") as session:
+    with util.APISession("SM-get-linstor-volume-openers") as session:
         hosts = session.xenapi.host.get_all_records()
         for host_ref, host_record in hosts.items():
             node_name = host_record['hostname']
@@ -190,8 +190,7 @@ def get_controller_node_name():
         if res:
             return res.groups()[0]
 
-    apisession = util.timeout(5, util.APISession, "SM-linstorvolumemanager-get_controller_node_name")
-    session = apisession.session
+    session = util.timeout(5, util.APISession, "SM-get-linstor-controller-node-name").session
 
     for host_ref, host_record in session.xenapi.host.get_all_records().items():
         node_name = host_record['hostname']
@@ -214,8 +213,7 @@ def get_controller_node_name():
 def demote_drbd_resource(node_name, resource_name):
     PLUGIN_CMD = 'demoteDrbdResource'
 
-    apisession = util.timeout(5, util.APISession, "SM-linstorvolumemanager-demote_drbd_resource")
-    session = apisession.session
+    session = util.timeout(5, util.APISession, "SM-demote-drbd-resource").session
 
     for host_ref, host_record in session.xenapi.host.get_all_records().items():
         if host_record['hostname'] != node_name:
@@ -1418,8 +1416,7 @@ class LinstorVolumeManager(object):
             # It needs to be done locally by each host so we go through the linstor-manager plugin.
             # If we don't do this sometimes, the destroy will fail when trying to destroy the resource groups with:
             # "linstor-manager:destroy error: Failed to destroy SP `xcp-sr-linstor_group_thin_device` on node `r620-s2`: The specified storage pool 'xcp-sr-linstor_group_thin_device' on node 'r620-s2' can not be deleted as volumes / snapshot-volumes are still using it."
-            apisession = util.timeout(5, util.APISession, "SM-linstorvolumemanager-destroy")
-            session = apisession.session
+            session = util.timeout(5, util.APISession, "SM-linstor-destroy").session
             for host_ref in session.xenapi.host.get_all():
                 try:
                     response = session.xenapi.host.call_plugin(

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -101,28 +101,27 @@ def get_all_volume_openers(resource_name, volume) -> LinstorVolumeOpeners:
     volume = str(volume)
     openers = {}
 
-    session = util.get_localAPI_session()
+    with util.APISession("SM-linstorvolumemanager-get_all_volume_openers") as session:
+        hosts = session.xenapi.host.get_all_records()
+        for host_ref, host_record in hosts.items():
+            node_name = host_record['hostname']
+            try:
+                if not session.xenapi.host_metrics.get_record(
+                    host_record['metrics']
+                )['live']:
+                    # Ensure we call plugin on online hosts only.
+                    continue
 
-    hosts = session.xenapi.host.get_all_records()
-    for host_ref, host_record in hosts.items():
-        node_name = host_record['hostname']
-        try:
-            if not session.xenapi.host_metrics.get_record(
-                host_record['metrics']
-            )['live']:
-                # Ensure we call plugin on online hosts only.
-                continue
-
-            openers[node_name] = json.loads(
-                session.xenapi.host.call_plugin(host_ref, PLUGIN, PLUGIN_CMD, {
-                    'resourceName': resource_name,
-                    'volume': volume
-                })
-            )
-        except Exception as e:
-            util.SMlog('Failed to get openers of `{}` on `{}`: {}'.format(
-                resource_name, node_name, e
-            ))
+                openers[node_name] = json.loads(
+                    session.xenapi.host.call_plugin(host_ref, PLUGIN, PLUGIN_CMD, {
+                        'resourceName': resource_name,
+                        'volume': volume
+                    })
+                )
+            except Exception as e:
+                util.SMlog('Failed to get openers of `{}` on `{}`: {}'.format(
+                    resource_name, node_name, e
+                ))
 
     return openers
 
@@ -191,7 +190,8 @@ def get_controller_node_name():
         if res:
             return res.groups()[0]
 
-    session = util.timeout(5, util.get_localAPI_session)
+    apisession = util.timeout(5, util.APISession, "SM-linstorvolumemanager-get_controller_node_name")
+    session = apisession.session
 
     for host_ref, host_record in session.xenapi.host.get_all_records().items():
         node_name = host_record['hostname']
@@ -214,7 +214,8 @@ def get_controller_node_name():
 def demote_drbd_resource(node_name, resource_name):
     PLUGIN_CMD = 'demoteDrbdResource'
 
-    session = util.timeout(5, util.get_localAPI_session)
+    apisession = util.timeout(5, util.APISession, "SM-linstorvolumemanager-demote_drbd_resource")
+    session = apisession.session
 
     for host_ref, host_record in session.xenapi.host.get_all_records().items():
         if host_record['hostname'] != node_name:
@@ -1417,7 +1418,8 @@ class LinstorVolumeManager(object):
             # It needs to be done locally by each host so we go through the linstor-manager plugin.
             # If we don't do this sometimes, the destroy will fail when trying to destroy the resource groups with:
             # "linstor-manager:destroy error: Failed to destroy SP `xcp-sr-linstor_group_thin_device` on node `r620-s2`: The specified storage pool 'xcp-sr-linstor_group_thin_device' on node 'r620-s2' can not be deleted as volumes / snapshot-volumes are still using it."
-            session = util.timeout(5, util.get_localAPI_session)
+            apisession = util.timeout(5, util.APISession, "SM-linstorvolumemanager-destroy")
+            session = apisession.session
             for host_ref in session.xenapi.host.get_all():
                 try:
                     response = session.xenapi.host.call_plugin(

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -101,7 +101,7 @@ def get_all_volume_openers(resource_name, volume) -> LinstorVolumeOpeners:
     volume = str(volume)
     openers = {}
 
-    with util.APISession("SM-get-linstor-volume-openers") as session:
+    with util.ApiSession("SM-get-linstor-volume-openers") as session:
         hosts = session.xenapi.host.get_all_records()
         for host_ref, host_record in hosts.items():
             node_name = host_record['hostname']
@@ -190,7 +190,7 @@ def get_controller_node_name():
         if res:
             return res.groups()[0]
 
-    session = util.timeout(5, util.APISession, "SM-get-linstor-controller-node-name").session
+    session = util.timeout(5, util.ApiSession, "SM-get-linstor-controller-node-name").session
 
     for host_ref, host_record in session.xenapi.host.get_all_records().items():
         node_name = host_record['hostname']
@@ -213,7 +213,7 @@ def get_controller_node_name():
 def demote_drbd_resource(node_name, resource_name):
     PLUGIN_CMD = 'demoteDrbdResource'
 
-    session = util.timeout(5, util.APISession, "SM-demote-drbd-resource").session
+    session = util.timeout(5, util.ApiSession, "SM-demote-drbd-resource").session
 
     for host_ref, host_record in session.xenapi.host.get_all_records().items():
         if host_record['hostname'] != node_name:
@@ -1416,7 +1416,7 @@ class LinstorVolumeManager(object):
             # It needs to be done locally by each host so we go through the linstor-manager plugin.
             # If we don't do this sometimes, the destroy will fail when trying to destroy the resource groups with:
             # "linstor-manager:destroy error: Failed to destroy SP `xcp-sr-linstor_group_thin_device` on node `r620-s2`: The specified storage pool 'xcp-sr-linstor_group_thin_device' on node 'r620-s2' can not be deleted as volumes / snapshot-volumes are still using it."
-            session = util.timeout(5, util.APISession, "SM-linstor-destroy").session
+            session = util.timeout(5, util.ApiSession, "SM-linstor-destroy").session
             for host_ref in session.xenapi.host.get_all():
                 try:
                     response = session.xenapi.host.call_plugin(

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -282,6 +282,7 @@ if __name__ == '__main__':
     try:
         with util.APISession("SM-mpathcount") as api_session:
             main(api_session)
-    except xs_errors.XenError:
+    except xs_errors.XenError as e:
+        util.SMlog(f"MPATH: Failure `{e}`")
         sys.exit(-1)
     sys.exit(0)

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -53,15 +53,6 @@ def get_dm_major():
     return cached_DM_maj
 
 
-def mpc_exit(session, code):
-    if session is not None:
-        try:
-            session.xenapi.session.logout()
-        except:
-            pass
-    sys.exit(code)
-
-
 def match_host_id(s):
     regex = re.compile("^INSTALLATION_UUID")
     return regex.search(s, 0)
@@ -231,9 +222,9 @@ def check_xapi_is_enabled():
 
 if __name__ == '__main__':
     try:
-        session = util.get_localAPI_session()
-    except:
-        print("Unable to open local XAPI session")
+        apisession = util.APISession("SM-mpathcount")
+        session = apisession.session
+    except xs_errors.XenError:
         sys.exit(-1)
 
     localhost = session.xenapi.host.get_by_uuid(get_localhost_uuid())
@@ -252,7 +243,6 @@ if __name__ == '__main__':
         def _remove(key):
             session.xenapi.host.remove_from_other_config(localhost, key)
 
-
         def _add(key, val):
             session.xenapi.host.add_to_other_config(localhost, key, val)
         config = session.xenapi.host.get_other_config(localhost)
@@ -261,19 +251,18 @@ if __name__ == '__main__':
 
     except:
         util.SMlog("MPATH: Failure updating Host.other-config:mpath-boot db")
-        mpc_exit(session, -1)
+        sys.exit(-1)
 
     try:
         pbds = session.xenapi.PBD.get_all_records_where("field \"host\" = \"%s\"" % localhost)
     except:
-        mpc_exit(session, -1)
+        sys.exit(-1)
 
     try:
         mpath_status: Dict[str, str] = {}
         for pbd in pbds:
             def remove(key):
                 session.xenapi.PBD.remove_from_other_config(pbd, key)
-
 
             def add(key, val):
                 session.xenapi.PBD.add_to_other_config(pbd, key, val)
@@ -290,8 +279,8 @@ if __name__ == '__main__':
         os.chmod(MPATH_FILE_NAME, 0o0644)
     except:
         util.SMlog("MPATH: Failure updating db. %s" % str(sys.exc_info()))
-        mpc_exit(session, -1)
+        sys.exit(-1)
 
     util.SMlog("MPATH: Update done")
 
-    mpc_exit(session, 0)
+    sys.exit(0)

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -280,7 +280,7 @@ def main(session):
 
 if __name__ == '__main__':
     try:
-        with util.APISession("SM-mpathcount") as api_session:
+        with util.ApiSession("SM-mpathcount") as api_session:
             main(api_session)
     except xs_errors.XenError as e:
         util.SMlog(f"MPATH: Failure `{e}`")

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -220,12 +220,8 @@ def check_xapi_is_enabled():
         util.SMlog(f"XAPI health check failed: {stderr}")
     return returncode == 0
 
-if __name__ == '__main__':
-    try:
-        session = util.APISession("SM-mpathcount").session
-    except xs_errors.XenError:
-        sys.exit(-1)
-
+def main(session):
+    global mpath_enabled
     localhost = session.xenapi.host.get_by_uuid(get_localhost_uuid())
     check_xapi_is_enabled()
     # Check whether multipathing is enabled (either for root dev or SRs)
@@ -282,4 +278,10 @@ if __name__ == '__main__':
 
     util.SMlog("MPATH: Update done")
 
+if __name__ == '__main__':
+    try:
+        with util.APISession("SM-mpathcount") as api_session:
+            main(api_session)
+    except xs_errors.XenError:
+        sys.exit(-1)
     sys.exit(0)

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -222,8 +222,7 @@ def check_xapi_is_enabled():
 
 if __name__ == '__main__':
     try:
-        apisession = util.APISession("SM-mpathcount")
-        session = apisession.session
+        session = util.APISession("SM-mpathcount").session
     except xs_errors.XenError:
         sys.exit(-1)
 

--- a/drivers/plugins/keymanagerutil.py
+++ b/drivers/plugins/keymanagerutil.py
@@ -39,9 +39,7 @@ def load_key(key_hash, vdi_uuid):
 
 
 def _check_key(key_hash, vdi_uuid):
-    session = XenAPI.xapi_local()
-    session.xenapi.login_with_password('root', '', '', PROGRAM_NAME)
-    try:
+    with util.APISession(PROGRAM_NAME) as session:
         vdi = session.xenapi.VDI.get_by_uuid(vdi_uuid)
         sm_config = session.xenapi.VDI.get_sm_config(vdi)
         if 'key_hash' in sm_config:
@@ -54,8 +52,6 @@ def _check_key(key_hash, vdi_uuid):
             raise Exception('Encryption key requested for VDI {}'
                             ' whose sm_config does not contain the key_hash'
                             ' entry. Its sm_config is {}'.format(vdi_uuid, sm_config))
-    finally:
-        session.xenapi.logout()
 
 
 class InputError(Exception):

--- a/drivers/plugins/keymanagerutil.py
+++ b/drivers/plugins/keymanagerutil.py
@@ -39,7 +39,7 @@ def load_key(key_hash, vdi_uuid):
 
 
 def _check_key(key_hash, vdi_uuid):
-    with util.APISession(PROGRAM_NAME) as session:
+    with util.ApiSession(PROGRAM_NAME) as session:
         vdi = session.xenapi.VDI.get_by_uuid(vdi_uuid)
         sm_config = session.xenapi.VDI.get_sm_config(vdi)
         if 'key_hash' in sm_config:

--- a/drivers/resetvdis.py
+++ b/drivers/resetvdis.py
@@ -139,43 +139,46 @@ def usage():
     sys.exit(1)
 
 
+def main(session):
+    mode = sys.argv[1]
+    if mode == "all":
+        if len(sys.argv) not in [4, 5]:
+            usage()
+        host_uuid = sys.argv[2]
+        sr_uuid = sys.argv[3]
+        is_master = False
+        if len(sys.argv) == 5:
+            if sys.argv[4] == "--master":
+                is_master = True
+            else:
+                usage()
+        reset_sr(session, host_uuid, sr_uuid, is_master)
+    elif mode == "single":
+        vdi_uuid = sys.argv[2]
+        force = False
+        if len(sys.argv) == 4 and sys.argv[3] == "--force":
+            force = True
+        reset_vdi(session, vdi_uuid, force)
+    elif len(sys.argv) in [3, 4]:
+        # backwards compatibility: the arguments for the "all" case used to be
+        # just host_uuid, sr_uuid, [is_master] (i.e., no "all" string, since it
+        # was the only mode available). To avoid having to change XAPI, accept
+        # the old format here as well.
+        host_uuid = sys.argv[1]
+        sr_uuid = sys.argv[2]
+        is_master = False
+        if len(sys.argv) == 4:
+            if sys.argv[3] == "--master":
+                is_master = True
+            else:
+                usage()
+        reset_sr(session, host_uuid, sr_uuid, is_master)
+    else:
+        usage()
+
 if __name__ == '__main__':
     if len(sys.argv) not in [3, 4, 5]:
         usage()
 
     with util.APISession("SM-resetvdis") as session:
-        mode = sys.argv[1]
-        if mode == "all":
-            if len(sys.argv) not in [4, 5]:
-                usage()
-            host_uuid = sys.argv[2]
-            sr_uuid = sys.argv[3]
-            is_master = False
-            if len(sys.argv) == 5:
-                if sys.argv[4] == "--master":
-                    is_master = True
-                else:
-                    usage()
-            reset_sr(session, host_uuid, sr_uuid, is_master)
-        elif mode == "single":
-            vdi_uuid = sys.argv[2]
-            force = False
-            if len(sys.argv) == 4 and sys.argv[3] == "--force":
-                force = True
-            reset_vdi(session, vdi_uuid, force)
-        elif len(sys.argv) in [3, 4]:
-            # backwards compatibility: the arguments for the "all" case used to be
-            # just host_uuid, sr_uuid, [is_master] (i.e., no "all" string, since it
-            # was the only mode available). To avoid having to change XAPI, accept
-            # the old format here as well.
-            host_uuid = sys.argv[1]
-            sr_uuid = sys.argv[2]
-            is_master = False
-            if len(sys.argv) == 4:
-                if sys.argv[3] == "--master":
-                    is_master = True
-                else:
-                    usage()
-            reset_sr(session, host_uuid, sr_uuid, is_master)
-        else:
-            usage()
+        main(session)

--- a/drivers/resetvdis.py
+++ b/drivers/resetvdis.py
@@ -138,48 +138,44 @@ def usage():
             "the VDI is not in use before running this script.")
     sys.exit(1)
 
-if __name__ == '__main__':
-    import atexit
 
+if __name__ == '__main__':
     if len(sys.argv) not in [3, 4, 5]:
         usage()
 
-    session = XenAPI.xapi_local()
-    session.xenapi.login_with_password('root', '', '', 'SM')
-    atexit.register(session.xenapi.session.logout)
-
-    mode = sys.argv[1]
-    if mode == "all":
-        if len(sys.argv) not in [4, 5]:
+    with util.APISession("SM-resetvdis") as session:
+        mode = sys.argv[1]
+        if mode == "all":
+            if len(sys.argv) not in [4, 5]:
+                usage()
+            host_uuid = sys.argv[2]
+            sr_uuid = sys.argv[3]
+            is_master = False
+            if len(sys.argv) == 5:
+                if sys.argv[4] == "--master":
+                    is_master = True
+                else:
+                    usage()
+            reset_sr(session, host_uuid, sr_uuid, is_master)
+        elif mode == "single":
+            vdi_uuid = sys.argv[2]
+            force = False
+            if len(sys.argv) == 4 and sys.argv[3] == "--force":
+                force = True
+            reset_vdi(session, vdi_uuid, force)
+        elif len(sys.argv) in [3, 4]:
+            # backwards compatibility: the arguments for the "all" case used to be
+            # just host_uuid, sr_uuid, [is_master] (i.e., no "all" string, since it
+            # was the only mode available). To avoid having to change XAPI, accept
+            # the old format here as well.
+            host_uuid = sys.argv[1]
+            sr_uuid = sys.argv[2]
+            is_master = False
+            if len(sys.argv) == 4:
+                if sys.argv[3] == "--master":
+                    is_master = True
+                else:
+                    usage()
+            reset_sr(session, host_uuid, sr_uuid, is_master)
+        else:
             usage()
-        host_uuid = sys.argv[2]
-        sr_uuid = sys.argv[3]
-        is_master = False
-        if len(sys.argv) == 5:
-            if sys.argv[4] == "--master":
-                is_master = True
-            else:
-                usage()
-        reset_sr(session, host_uuid, sr_uuid, is_master)
-    elif mode == "single":
-        vdi_uuid = sys.argv[2]
-        force = False
-        if len(sys.argv) == 4 and sys.argv[3] == "--force":
-            force = True
-        reset_vdi(session, vdi_uuid, force)
-    elif len(sys.argv) in [3, 4]:
-        # backwards compatibility: the arguments for the "all" case used to be
-        # just host_uuid, sr_uuid, [is_master] (i.e., no "all" string, since it
-        # was the only mode available). To avoid having to change XAPI, accept
-        # the old format here as well.
-        host_uuid = sys.argv[1]
-        sr_uuid = sys.argv[2]
-        is_master = False
-        if len(sys.argv) == 4:
-            if sys.argv[3] == "--master":
-                is_master = True
-            else:
-                usage()
-        reset_sr(session, host_uuid, sr_uuid, is_master)
-    else:
-        usage()

--- a/drivers/resetvdis.py
+++ b/drivers/resetvdis.py
@@ -180,5 +180,5 @@ if __name__ == '__main__':
     if len(sys.argv) not in [3, 4, 5]:
         usage()
 
-    with util.APISession("SM-resetvdis") as session:
+    with util.ApiSession("SM-resetvdis") as session:
         main(session)

--- a/drivers/sr_health_check.py
+++ b/drivers/sr_health_check.py
@@ -33,7 +33,7 @@ def main():
     """
     For all locally plugged SRs check that they are healthy
     """
-    with util.APISession("SM-sr-health-check") as session:
+    with util.ApiSession("SM-sr-health-check") as session:
         localhost = util.get_localhost_ref(session)
         if not check_xapi_is_enabled(session, localhost):
             # Xapi not enabled, skip and let the next timer trigger this

--- a/drivers/sr_health_check.py
+++ b/drivers/sr_health_check.py
@@ -33,7 +33,7 @@ def main():
     """
     For all locally plugged SRs check that they are healthy
     """
-    with util.APISession("SM-sr_health_check") as session:
+    with util.APISession("SM-sr-health-check") as session:
         localhost = util.get_localhost_ref(session)
         if not check_xapi_is_enabled(session, localhost):
             # Xapi not enabled, skip and let the next timer trigger this

--- a/drivers/sr_health_check.py
+++ b/drivers/sr_health_check.py
@@ -33,13 +33,7 @@ def main():
     """
     For all locally plugged SRs check that they are healthy
     """
-    try:
-        session = util.get_localAPI_session()
-    except xs_errors.SROSError:
-        util.SMlog("Unable to open local XAPI session", priority=util.LOG_ERR)
-        return
-
-    try:
+    with util.APISession("SM-sr_health_check") as session:
         localhost = util.get_localhost_ref(session)
         if not check_xapi_is_enabled(session, localhost):
             # Xapi not enabled, skip and let the next timer trigger this
@@ -63,8 +57,6 @@ def main():
                 sr_uuid = srs[sr]['uuid']
                 sr_obj = SR.SR.from_uuid(session, sr_uuid)
                 sr_obj.check_sr(sr_uuid)
-    finally:
-        session.xenapi.session.logout()
 
 
 if __name__ == "__main__":

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -470,19 +470,21 @@ def ioretry_stat(path, maxretry=IORETRY_MAX):
 def sr_get_capability(sr_uuid, session=None):
     result = []
     api_session = None
-    if session is None:
-        api_session = APISession("SM-sr-get-capability")
-        session = api_session.session
-    sr_ref = session.xenapi.SR.get_by_uuid(sr_uuid)
-    sm_type = session.xenapi.SR.get_record(sr_ref)['type']
-    sm_rec = session.xenapi.SM.get_all_records_where(
-        "field \"type\" = \"%s\"" % sm_type)
+    try:
+        if session is None:
+            api_session = APISession("SM-sr-get-capability")
+            session = api_session.session
+        sr_ref = session.xenapi.SR.get_by_uuid(sr_uuid)
+        sm_type = session.xenapi.SR.get_record(sr_ref)['type']
+        sm_rec = session.xenapi.SM.get_all_records_where(
+            "field \"type\" = \"%s\"" % sm_type)
 
-    # SM expects at least one entry of any SR type
-    if len(sm_rec) > 0:
-        result = list(sm_rec.values())[0]['capabilities']
-    if api_session:
-        session.logout()
+        # SM expects at least one entry of any SR type
+        if len(sm_rec) > 0:
+            result = list(sm_rec.values())[0]['capabilities']
+    finally:
+        if api_session:
+            session.logout()
     return result
 
 def sr_get_driver_info(driver_info):

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -775,7 +775,7 @@ def getrootdevID():
 
 
 class ApiSession(contextlib.AbstractContextManager):
-    session=None
+    session = None
 
     def __init__(self, originator="SM"):
         self.originator = originator
@@ -790,7 +790,10 @@ class ApiSession(contextlib.AbstractContextManager):
         try:
             session.xenapi.login_with_password('root', '', '', self.originator)
         except Exception as exc:
-            raise xs_errors.XenError(f"ApiSession [{self.originator}] Unable to open local XAPI session") from exc
+            raise xs_errors.XenError(
+                "APISession",
+                opterr=f"[{self.originator}] Unable to open local XAPI session"
+            ) from exc
         SMlog("ApiSession [{}] login".format(self.originator), priority=LOG_DEBUG)
         return session
 

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -787,7 +787,8 @@ class APISession:
             raise xs_errors.XenError(msg) from exc
         return session
 
-    def logout(self, log="logout"):
+    def _logout(self, log):
+        """Closes an API session"""
         if self.session is None:
             SMlog("APISession [{}] session is None {}".format(self.originator, log))
             return
@@ -795,13 +796,16 @@ class APISession:
         SMlog("APISession [{}] {}".format(self.originator, log))
         self.session = None
 
-    def __del__(self):
-        """Closes an API session"""
+    def logout(self, log="logout"):
         atexit.unregister(self.atexit)
-        self.logout(log="logout del")
+        self._logout(log=log)
+
+    def __del__(self):
+        if self.session:
+            self.logout(log="logout del")
 
     def atexit(self):
-        self.logout(log="logout atexit")
+        self._logout(log="logout atexit")
 
     def __enter__(self):
         return self.session

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -472,7 +472,7 @@ def sr_get_capability(sr_uuid, session=None):
     api_session = None
     try:
         if session is None:
-            api_session = APISession("SM-sr-get-capability")
+            api_session = ApiSession("SM-sr-get-capability")
             session = api_session.session
         sr_ref = session.xenapi.SR.get_by_uuid(sr_uuid)
         sm_type = session.xenapi.SR.get_record(sr_ref)['type']
@@ -774,7 +774,7 @@ def getrootdevID():
     return rootdevID
 
 
-class APISession(contextlib.AbstractContextManager):
+class ApiSession(contextlib.AbstractContextManager):
     session=None
 
     def __init__(self, originator="SM"):
@@ -790,17 +790,17 @@ class APISession(contextlib.AbstractContextManager):
         try:
             session.xenapi.login_with_password('root', '', '', self.originator)
         except Exception as exc:
-            raise xs_errors.XenError(f"APISession [{self.originator}] Unable to open local XAPI session") from exc
-        SMlog("APISession [{}] login".format(self.originator), priority=LOG_DEBUG)
+            raise xs_errors.XenError(f"ApiSession [{self.originator}] Unable to open local XAPI session") from exc
+        SMlog("ApiSession [{}] login".format(self.originator), priority=LOG_DEBUG)
         return session
 
     def _logout(self, log):
         """Closes an API session"""
         if self.session is None:
-            SMlog("APISession [{}] session is None {}".format(self.originator, log), priority=LOG_DEBUG)
+            SMlog("ApiSession [{}] session is None {}".format(self.originator, log), priority=LOG_DEBUG)
             return
         self.session.xenapi.session.logout()
-        SMlog("APISession [{}] {}".format(self.originator, log), priority=LOG_DEBUG)
+        SMlog("ApiSession [{}] {}".format(self.originator, log), priority=LOG_DEBUG)
         self.session = None
 
     def logout(self, log="logout"):
@@ -1493,7 +1493,7 @@ class FistPoint:
         return os.path.exists("/tmp/fist_%s" % name)
 
     def mark_sr(self, name, sruuid, started):
-        with APISession("SM-sr-fist-point") as session:
+        with ApiSession("SM-sr-fist-point") as session:
             sr = session.xenapi.SR.get_by_uuid(sruuid)
             if started:
                 session.xenapi.SR.add_to_other_config(sr, name, "active")

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -19,6 +19,7 @@
 from sm_typing import Any, List, Optional, override
 
 import contextlib
+import atexit
 import os
 import re
 import sys
@@ -467,25 +468,19 @@ def ioretry_stat(path, maxretry=IORETRY_MAX):
 
 def sr_get_capability(sr_uuid, session=None):
     result = []
-    local_session = None
     if session is None:
-        local_session = get_localAPI_session()
-        session = local_session
+        apisession = APISession("SM-util-sr_get_capability")
+        session = apisession.session
+    sr_ref = session.xenapi.SR.get_by_uuid(sr_uuid)
+    sm_type = session.xenapi.SR.get_record(sr_ref)['type']
+    sm_rec = session.xenapi.SM.get_all_records_where(
+        "field \"type\" = \"%s\"" % sm_type)
 
-    try:
-        sr_ref = session.xenapi.SR.get_by_uuid(sr_uuid)
-        sm_type = session.xenapi.SR.get_record(sr_ref)['type']
-        sm_rec = session.xenapi.SM.get_all_records_where(
-            "field \"type\" = \"%s\"" % sm_type)
+    # SM expects at least one entry of any SR type
+    if len(sm_rec) > 0:
+        result = list(sm_rec.values())[0]['capabilities']
 
-        # SM expects at least one entry of any SR type
-        if len(sm_rec) > 0:
-            result = list(sm_rec.values())[0]['capabilities']
-
-        return result
-    finally:
-        if local_session:
-            local_session.xenapi.session.logout()
+    return result
 
 def sr_get_driver_info(driver_info):
     results = {}
@@ -774,14 +769,45 @@ def getrootdevID():
     return rootdevID
 
 
-def get_localAPI_session():
-    # First acquire a valid session
-    session = XenAPI.xapi_local()
-    try:
-        session.xenapi.login_with_password('root', '', '', 'SM')
-    except:
-        raise xs_errors.XenError('APISession')
-    return session
+class APISession:
+    def __init__(self, originator="SM"):
+        self.originator = originator
+        self.session = self.login()
+        SMlog("APISession [{}] login".format(self.originator))
+        atexit.register(self.atexit)
+
+    def login(self):
+        # First acquire a valid session
+        session = XenAPI.xapi_local()
+        try:
+            session.xenapi.login_with_password('root', '', '', self.originator)
+        except Exception as exc:
+            msg = f"APISession [{self.originator}] Unable to open local XAPI session"
+            SMlog(msg)
+            raise xs_errors.XenError(msg) from exc
+        return session
+
+    def logout(self, log="logout"):
+        if self.session is None:
+            SMlog("APISession [{}] session is None {}".format(self.originator, log))
+            return
+        self.session.xenapi.session.logout()
+        SMlog("APISession [{}] {}".format(self.originator, log))
+        self.session = None
+
+    def __del__(self):
+        """Closes an API session"""
+        atexit.unregister(self.atexit)
+        self.logout(log="logout del")
+
+    def atexit(self):
+        self.logout(log="logout atexit")
+
+    def __enter__(self):
+        return self.session
+
+    def __exit__(self, _type, _value, _traceback):
+        self.logout(log=f"logout exception[{_type}] {_value}" if _type else "logout context")
 
 
 def xapi_safe_call(function):
@@ -1453,16 +1479,12 @@ class FistPoint:
         return os.path.exists("/tmp/fist_%s" % name)
 
     def mark_sr(self, name, sruuid, started):
-        session = get_localAPI_session()
-        try:
+        with APISession("SM-util-FistPoint-mark_sr") as session:
             sr = session.xenapi.SR.get_by_uuid(sruuid)
-
             if started:
                 session.xenapi.SR.add_to_other_config(sr, name, "active")
             else:
                 session.xenapi.SR.remove_from_other_config(sr, name)
-        finally:
-            session.xenapi.session.logout()
 
     def activate(self, name, sruuid):
         if name in self.points:

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -469,9 +469,10 @@ def ioretry_stat(path, maxretry=IORETRY_MAX):
 
 def sr_get_capability(sr_uuid, session=None):
     result = []
+    api_session = None
     if session is None:
-        apisession = APISession("SM-util-sr_get_capability")
-        session = apisession.session
+        api_session = APISession("SM-sr-get-capability")
+        session = api_session.session
     sr_ref = session.xenapi.SR.get_by_uuid(sr_uuid)
     sm_type = session.xenapi.SR.get_record(sr_ref)['type']
     sm_rec = session.xenapi.SM.get_all_records_where(
@@ -480,7 +481,8 @@ def sr_get_capability(sr_uuid, session=None):
     # SM expects at least one entry of any SR type
     if len(sm_rec) > 0:
         result = list(sm_rec.values())[0]['capabilities']
-
+    if api_session:
+        session.logout()
     return result
 
 def sr_get_driver_info(driver_info):
@@ -773,19 +775,17 @@ def getrootdevID():
 class APISession(contextlib.AbstractContextManager):
     def __init__(self, originator="SM"):
         self.originator = originator
-        self.session = self.login()
-        SMlog("APISession [{}] login".format(self.originator), priority=LOG_DEBUG)
-        atexit.register(self.atexit)
-
-    def login(self):
         # First acquire a valid session
+        self.session = self._login()
+        SMlog("APISession [{}] login".format(self.originator), priority=LOG_DEBUG)
+        atexit.register(self._atexit)
+
+    def _login(self):
         session = XenAPI.xapi_local()
         try:
             session.xenapi.login_with_password('root', '', '', self.originator)
         except Exception as exc:
-            msg = f"APISession [{self.originator}] Unable to open local XAPI session"
-            SMlog(msg, priority=LOG_ERR)
-            raise xs_errors.XenError(msg) from exc
+            raise xs_errors.XenError(f"APISession [{self.originator}] Unable to open local XAPI session") from exc
         return session
 
     def _logout(self, log):
@@ -798,14 +798,14 @@ class APISession(contextlib.AbstractContextManager):
         self.session = None
 
     def logout(self, log="logout"):
-        atexit.unregister(self.atexit)
+        atexit.unregister(self._atexit)
         self._logout(log=log)
 
     def __del__(self):
         if self.session:
             self.logout(log="logout del")
 
-    def atexit(self):
+    def _atexit(self):
         self._logout(log="logout atexit")
 
     @override

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -47,7 +47,8 @@ import resource
 import traceback
 import glob
 import copy
-import tempfile
+import contextlib
+from sm_typing import override
 
 from functools import reduce
 from sm_typing import List, Optional
@@ -769,11 +770,11 @@ def getrootdevID():
     return rootdevID
 
 
-class APISession:
+class APISession(contextlib.AbstractContextManager):
     def __init__(self, originator="SM"):
         self.originator = originator
         self.session = self.login()
-        SMlog("APISession [{}] login".format(self.originator))
+        SMlog("APISession [{}] login".format(self.originator), priority=LOG_DEBUG)
         atexit.register(self.atexit)
 
     def login(self):
@@ -783,17 +784,17 @@ class APISession:
             session.xenapi.login_with_password('root', '', '', self.originator)
         except Exception as exc:
             msg = f"APISession [{self.originator}] Unable to open local XAPI session"
-            SMlog(msg)
+            SMlog(msg, priority=LOG_ERR)
             raise xs_errors.XenError(msg) from exc
         return session
 
     def _logout(self, log):
         """Closes an API session"""
         if self.session is None:
-            SMlog("APISession [{}] session is None {}".format(self.originator, log))
+            SMlog("APISession [{}] session is None {}".format(self.originator, log), priority=LOG_DEBUG)
             return
         self.session.xenapi.session.logout()
-        SMlog("APISession [{}] {}".format(self.originator, log))
+        SMlog("APISession [{}] {}".format(self.originator, log), priority=LOG_DEBUG)
         self.session = None
 
     def logout(self, log="logout"):
@@ -807,9 +808,13 @@ class APISession:
     def atexit(self):
         self._logout(log="logout atexit")
 
+    @override
     def __enter__(self):
+        if not self.session:
+            raise SyntaxError("Session is already closed: wrong usage of context.")
         return self.session
 
+    @override
     def __exit__(self, _type, _value, _traceback):
         self.logout(log=f"logout exception[{_type}] {_value}" if _type else "logout context")
 

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -773,19 +773,23 @@ def getrootdevID():
 
 
 class APISession(contextlib.AbstractContextManager):
+    session=None
+
     def __init__(self, originator="SM"):
         self.originator = originator
         # First acquire a valid session
         self.session = self._login()
-        SMlog("APISession [{}] login".format(self.originator), priority=LOG_DEBUG)
         atexit.register(self._atexit)
 
     def _login(self):
+        if self.session:
+            return self.session
         session = XenAPI.xapi_local()
         try:
             session.xenapi.login_with_password('root', '', '', self.originator)
         except Exception as exc:
             raise xs_errors.XenError(f"APISession [{self.originator}] Unable to open local XAPI session") from exc
+        SMlog("APISession [{}] login".format(self.originator), priority=LOG_DEBUG)
         return session
 
     def _logout(self, log):
@@ -810,8 +814,7 @@ class APISession(contextlib.AbstractContextManager):
 
     @override
     def __enter__(self):
-        if not self.session:
-            raise SyntaxError("Session is already closed: wrong usage of context.")
+        self.session = self._login()
         return self.session
 
     @override
@@ -1488,7 +1491,7 @@ class FistPoint:
         return os.path.exists("/tmp/fist_%s" % name)
 
     def mark_sr(self, name, sruuid, started):
-        with APISession("SM-util-FistPoint-mark_sr") as session:
+        with APISession("SM-sr-fist-point") as session:
             sr = session.xenapi.SR.get_by_uuid(sruuid)
             if started:
                 session.xenapi.SR.add_to_other_config(sr, name, "active")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -60,6 +60,7 @@ class TestRelease(object):
 class IrrelevantLock(object):
     pass
 
+
 def create_cleanup_sr(xapi, uuid=None):
     return cleanup.SR(uuid=uuid, xapi=xapi, createLock=False, force=False)
 
@@ -85,9 +86,9 @@ class TestSR(unittest.TestCase):
         self.xapi_mock.isMaster.return_value = True
         self.mock_xapi_session = mock.MagicMock(name="MockSession")
 
-        util_apisession_patcher = mock.patch('cleanup.util.APISession.login')
-        self.mock_util_apisession_patcher = util_apisession_patcher.start()
-        self.mock_util_apisession_patcher.return_value = self.mock_xapi_session
+        util_api_session_patcher = mock.patch('cleanup.util.APISession._login')
+        self.mock_util_api_session_patcher = util_api_session_patcher.start()
+        self.mock_util_api_session_patcher.return_value = self.mock_xapi_session
 
         self.addCleanup(mock.patch.stopall)
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -86,7 +86,7 @@ class TestSR(unittest.TestCase):
         self.xapi_mock.isMaster.return_value = True
         self.mock_xapi_session = mock.MagicMock(name="MockSession")
 
-        util_api_session_patcher = mock.patch('cleanup.util.APISession._login')
+        util_api_session_patcher = mock.patch('cleanup.util.ApiSession._login')
         self.mock_util_api_session_patcher = util_api_session_patcher.start()
         self.mock_util_api_session_patcher.return_value = self.mock_xapi_session
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -60,7 +60,6 @@ class TestRelease(object):
 class IrrelevantLock(object):
     pass
 
-
 def create_cleanup_sr(xapi, uuid=None):
     return cleanup.SR(uuid=uuid, xapi=xapi, createLock=False, force=False)
 
@@ -85,7 +84,10 @@ class TestSR(unittest.TestCase):
         self.xapi_mock.isPluggedHere.return_value = True
         self.xapi_mock.isMaster.return_value = True
         self.mock_xapi_session = mock.MagicMock(name="MockSession")
-        self.xapi_mock.getSession.return_value = self.mock_xapi_session
+
+        util_apisession_patcher = mock.patch('cleanup.util.APISession.login')
+        self.mock_util_apisession_patcher = util_apisession_patcher.start()
+        self.mock_util_apisession_patcher.return_value = self.mock_xapi_session
 
         self.addCleanup(mock.patch.stopall)
 

--- a/tests/test_mpathcount.py
+++ b/tests/test_mpathcount.py
@@ -178,39 +178,6 @@ class TestMpathCount(unittest.TestCase):
         self.assertNotIn('mpath-3600a098038303973743f486833396d40', store)
 
     @mock.patch('mpathcount.sys.exit', autospec=True)
-    def test_exit_logs_out(self, mock_exit):
-        # Arrange
-        session = mock.MagicMock()
-
-        # Act
-        mpathcount.mpc_exit(session, 0)
-
-        # Assert
-        mock_exit.assert_called_once_with(0)
-        session.xenapi.session.logout.assert_called_once()
-
-    @mock.patch('mpathcount.sys.exit', autospec=True)
-    def test_exit_no_session(self, mock_exit):
-        # Act
-        mpathcount.mpc_exit(None, 0)
-
-        # Assert
-        mock_exit.assert_called_once_with(0)
-
-    @mock.patch('mpathcount.sys.exit', autospec=True)
-    def test_exit_log_out_error(self, mock_exit):
-        # Arrange
-        session = mock.MagicMock()
-        session.xenapi.session.logout.side_effect = XenAPI.Failure
-
-        # Act
-        mpathcount.mpc_exit(session, 0)
-
-        # Assert
-        mock_exit.assert_called_once_with(0)
-        session.xenapi.session.logout.assert_called_once()
-
-    @mock.patch('mpathcount.sys.exit', autospec=True)
     @mock.patch('mpathcount.util.SMlog', autospec=True)
     @mock.patch('mpathcount.subprocess.Popen', autospec=True)
     def test_check_xapi_enabled_yes(self, mock_popen, mock_smlog, mock_exit):

--- a/tests/test_sr_health_check.py
+++ b/tests/test_sr_health_check.py
@@ -17,9 +17,9 @@ class TestSrHealthCheck(unittest.TestCase):
         util_patcher = mock.patch('sr_health_check.util')
         self.mock_util = util_patcher.start()
         self.mock_session = mock.MagicMock()
-        self.mock_apisession = mock.MagicMock()
-        self.mock_util.APISession.return_value = self.mock_apisession
-        self.mock_apisession.__enter__.return_value = self.mock_session
+        self.mock_api_session = mock.MagicMock()
+        self.mock_util.APISession.return_value = self.mock_api_session
+        self.mock_api_session.__enter__.return_value = self.mock_session
         sr_patcher = mock.patch('sr_health_check.SR.SR', autospec=True)
         self.mock_sr = sr_patcher.start()
 

--- a/tests/test_sr_health_check.py
+++ b/tests/test_sr_health_check.py
@@ -17,7 +17,9 @@ class TestSrHealthCheck(unittest.TestCase):
         util_patcher = mock.patch('sr_health_check.util')
         self.mock_util = util_patcher.start()
         self.mock_session = mock.MagicMock()
-        self.mock_util.get_localAPI_session.return_value = self.mock_session
+        self.mock_apisession = mock.MagicMock()
+        self.mock_util.APISession.return_value = self.mock_apisession
+        self.mock_apisession.__enter__.return_value = self.mock_session
         sr_patcher = mock.patch('sr_health_check.SR.SR', autospec=True)
         self.mock_sr = sr_patcher.start()
 

--- a/tests/test_sr_health_check.py
+++ b/tests/test_sr_health_check.py
@@ -18,7 +18,7 @@ class TestSrHealthCheck(unittest.TestCase):
         self.mock_util = util_patcher.start()
         self.mock_session = mock.MagicMock()
         self.mock_api_session = mock.MagicMock()
-        self.mock_util.APISession.return_value = self.mock_api_session
+        self.mock_util.ApiSession.return_value = self.mock_api_session
         self.mock_api_session.__enter__.return_value = self.mock_session
         sr_patcher = mock.patch('sr_health_check.SR.SR', autospec=True)
         self.mock_sr = sr_patcher.start()


### PR DESCRIPTION
New `APISession` class to handle lifecycle of the session, with context, or `atexit` handlers.
Use various originator for `xapi` session creation, to differentiate where they are being created.

`APISession` uses `get_localAPI_session()` for session creation, so there is only one place for session creation, using `xenapi.login_with_password`.
`get_localAPI_session` should be avoided and only remain in `lcache.py`.

The session `originator` is shown on all logs messages pertaining to sessions, in SMlog, in the format `APISession [{originator}] {message}`.
All login and logout messages starts with login or logout hence it is possible to count them to check if there is session leakage :
```sh
$ echo "login: $(grep -e 'APISession \[.*\] login' SMlog* | wc -l), logout: $(grep -e 'APISession \[.*\] logout' SMlog* | wc -l)"
login: 8024, logout: 8024
```