### PR TITLE
feat(SR): add a supported image format list defined by drivers

### DIFF
--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -33,7 +33,7 @@ import blktap2
 import time
 import glob
 from uuid import uuid4
-from cowutil import getCowUtil, getImageStringFromVdiType, getVdiTypeFromImageFormat
+from cowutil import getCowUtil, getImageStringFromVdiType
 from vditype import VdiType, VdiTypeExtension, VDI_COW_TYPES, VDI_TYPE_TO_EXTENSION
 import xmlrpc.client
 import XenAPI # pylint: disable=import-error
@@ -95,7 +95,7 @@ class FileSR(SR.SR):
         # "super" sometimes failed due to circular imports
         SR.SR.__init__(self, srcmd, sr_uuid)
         self.image_info = {}
-        self._init_preferred_image_formats()
+        self._init_image_formats()
         self._check_o_direct()
 
     @override
@@ -440,11 +440,6 @@ class FileVDI(VDI.VDI):
     PARAM_RAW = "raw"
     PARAM_VHD = "vhd"
     PARAM_QCOW2 = "qcow2"
-    VDI_TYPE = {
-            PARAM_RAW: VdiType.RAW,
-            PARAM_VHD: VdiType.VHD,
-            PARAM_QCOW2: VdiType.QCOW2
-    }
 
     def _find_path_with_retries(self, vdi_uuid, maxretry=5, period=2.0):
         raw_path = os.path.join(self.sr.path, "%s.%s" % \
@@ -496,22 +491,18 @@ class FileVDI(VDI.VDI):
         self.sr.srcmd.params['o_direct'] = self.sr.o_direct
 
         if self.sr.srcmd.cmd == "vdi_create":
+            image_format = None
             self.key_hash = None
 
             vdi_sm_config = self.sr.srcmd.params.get("vdi_sm_config")
             if vdi_sm_config:
+                image_format = self.sr.read_config_image_format(vdi_sm_config)
                 self.key_hash = vdi_sm_config.get("key_hash")
 
-                image_format = vdi_sm_config.get("image-format") or vdi_sm_config.get("type")
-                if image_format:
-                    vdi_type = self.VDI_TYPE.get(image_format)
-                    if not vdi_type:
-                        raise xs_errors.XenError('VDIType',
-                                opterr='Invalid VDI type %s' % vdi_type)
-                    self.vdi_type = vdi_type
+            if not image_format:
+                image_format = self.sr.preferred_image_formats[0]
+            self.vdi_type = self.sr._resolve_vdi_type_from_image_format(image_format)
 
-            if not self.vdi_type:
-                self.vdi_type = getVdiTypeFromImageFormat(self.sr.preferred_image_formats[0])
             self.cowutil = getCowUtil(self.vdi_type)
             self.path = os.path.join(self.sr.path, "%s%s" %
                 (vdi_uuid, VDI_TYPE_TO_EXTENSION[self.vdi_type]))

--- a/drivers/LVMSR.py
+++ b/drivers/LVMSR.py
@@ -40,7 +40,7 @@ from journaler import Journaler
 from refcounter import RefCounter
 from ipc import IPCFlag
 from constants import NS_PREFIX_LVM, VG_LOCATION, VG_PREFIX
-from cowutil import CowUtil, getCowUtil, getImageStringFromVdiType, getVdiTypeFromImageFormat
+from cowutil import CowUtil, getCowUtil, getImageStringFromVdiType
 from lvmcowutil import LV_PREFIX, LvmCowUtil
 from lvmanager import LVActivator
 from vditype import VdiType
@@ -78,12 +78,6 @@ DRIVER_INFO = {
     'capabilities': CAPABILITIES,
     'configuration': CONFIGURATION
     }
-
-CREATE_PARAM_TYPES = {
-    "raw": VdiType.RAW,
-    "vhd": VdiType.VHD,
-    "qcow2": VdiType.QCOW2
-}
 
 OPS_EXCLUSIVE = [
         "sr_create", "sr_delete", "sr_attach", "sr_detach", "sr_scan",
@@ -157,7 +151,7 @@ class LVMSR(SR.SR):
 
     def __init__(self, srcmd, sr_uuid):
         SR.SR.__init__(self, srcmd, sr_uuid)
-        self._init_preferred_image_formats()
+        self._init_image_formats()
 
     @override
     def load(self, sr_uuid) -> None:
@@ -1364,22 +1358,21 @@ class LVMVDI(VDI.VDI):
         if self._determineType():
             return
 
+        image_format = None
+
         # the VDI must be in the process of being created
         self.exists = False
 
         vdi_sm_config = self.sr.srcmd.params.get("vdi_sm_config")
         if vdi_sm_config:
-            image_format = vdi_sm_config.get("image-format") or vdi_sm_config.get("type")
-            if image_format:
-                try:
-                    self._setType(CREATE_PARAM_TYPES[image_format])
-                except:
-                    raise xs_errors.XenError('VDICreate', opterr='bad image format')
-                if self.sr.legacyMode and self.sr.cmd == 'vdi_create' and VdiType.isCowImage(self.vdi_type):
-                    raise xs_errors.XenError('VDICreate', opterr='Cannot create COW type disk in legacy mode')
+            image_format = self.sr.read_config_image_format(vdi_sm_config)
 
-        if not self.vdi_type:
-            self._setType(getVdiTypeFromImageFormat(self.sr.preferred_image_formats[0]))
+        if not image_format:
+            image_format = self.sr.preferred_image_formats[0]
+        self.vdi_type = self.sr._resolve_vdi_type_from_image_format(image_format)
+
+        if self.sr.legacyMode and self.sr.cmd == 'vdi_create' and VdiType.isCowImage(self.vdi_type):
+            raise xs_errors.XenError('VDICreate', opterr='Cannot create COW type disk in legacy mode')
 
         self.lvname = "%s%s" % (LV_PREFIX[self.vdi_type], vdi_uuid)
         self.path = os.path.join(self.sr.path, self.lvname)

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -57,7 +57,7 @@ import xml.etree.ElementTree as xml_parser
 import xmlrpc.client
 import xs_errors
 
-from cowutil import CowUtil, ImageFormat, getImageStringFromVdiType, getVdiTypeFromImageFormat
+from cowutil import CowUtil, ImageFormat, getImageStringFromVdiType
 from srmetadata import \
     NAME_LABEL_TAG, NAME_DESCRIPTION_TAG, IS_A_SNAPSHOT_TAG, SNAPSHOT_OF_TAG, \
     TYPE_TAG, VDI_TYPE_TAG, READ_ONLY_TAG, SNAPSHOT_TIME_TAG, \
@@ -86,15 +86,6 @@ USE_KEY_HASH = False
 # Special volumes.
 HA_VOLUME_NAME = PERSISTENT_PREFIX + 'ha-statefile'
 REDO_LOG_VOLUME_NAME = PERSISTENT_PREFIX + 'redo-log'
-
-# TODO: Simplify with File SR and LVM SR
-# Warning: Not the same values than VdiType.*.
-# These values represents the types given on the command line.
-CREATE_PARAM_TYPES = {
-    "raw": VdiType.RAW,
-    "vhd": VdiType.VHD,
-    "qcow2": VdiType.QCOW2
-}
 
 # ==============================================================================
 
@@ -319,7 +310,10 @@ class LinstorSR(SR.SR):
 
     def __init__(self, srcmd, sr_uuid):
         SR.SR.__init__(self, srcmd, sr_uuid)
-        self._init_preferred_image_formats([ImageFormat.VHD])
+        self._init_image_formats(
+            preferred_image_formats=[ImageFormat.VHD],
+            supported_image_formats=[ImageFormat.RAW, ImageFormat.VHD]
+        )
 
     @override
     def load(self, sr_uuid) -> None:
@@ -1636,20 +1630,17 @@ class LinstorVDI(VDI.VDI):
 
             # 2. Or maybe a creation.
             if self.sr.srcmd.cmd == 'vdi_create':
+                image_format = None
                 self._key_hash = None  # Only used in create.
 
                 self._exists = False
                 vdi_sm_config = self.sr.srcmd.params.get('vdi_sm_config')
                 if vdi_sm_config:
-                    image_format = vdi_sm_config.get('image-format') or vdi_sm_config.get('type')
-                    if image_format:
-                        try:
-                            self._set_type(CREATE_PARAM_TYPES[image_format])
-                        except:
-                            raise xs_errors.XenError('VDICreate', opterr='bad image format')
+                    image_format = self.sr.read_config_image_format(vdi_sm_config)
 
-                if not self.vdi_type:
-                    self._set_type(getVdiTypeFromImageFormat(self.sr.preferred_image_formats[0]))
+                if not image_format:
+                    image_format = self.sr.preferred_image_formats[0]
+                self._set_type(self.sr._resolve_vdi_type_from_image_format(image_format))
 
                 if VdiType.isCowImage(self.vdi_type):
                     self._key_hash = vdi_sm_config.get('key_hash')

--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -18,7 +18,7 @@
 # SR: Base class for storage repositories
 #
 
-from sm_typing import List
+from sm_typing import Dict, List, Optional
 
 import VDI
 import xml.dom.minidom
@@ -30,8 +30,15 @@ import copy
 import os
 import traceback
 
-from cowutil import \
-    ImageFormat, getCowUtilFromImageFormat, getImageStringFromVdiType, getVdiTypeFromImageFormat, parseImageFormats
+from cowutil import (
+    getCowUtilFromImageFormat,
+    getImageStringFromVdiType,
+    getVdiTypeFromImageFormat,
+    ImageFormat,
+    parseImageFormats,
+    STR_TO_IMAGE_FORMAT
+)
+
 from vditype import VdiType
 
 MOUNT_BASE = '/var/run/sr-mount'
@@ -41,7 +48,8 @@ MASTER_LVM_CONF = '/etc/lvm/master'
 # LUN per VDI key for XenCenter
 LUNPERVDI = "LUNperVDI"
 
-DEFAULT_IMAGE_FORMATS = [ImageFormat.VHD, ImageFormat.QCOW2]
+DEFAULT_PREFERRED_IMAGE_FORMATS = [ImageFormat.VHD, ImageFormat.QCOW2]
+DEFAULT_SUPPORTED_IMAGE_FORMATS = [ImageFormat.RAW, ImageFormat.VHD, ImageFormat.QCOW2]
 
 
 
@@ -523,11 +531,35 @@ class SR(object):
 
         return missing_keys
 
-    def _init_preferred_image_formats(self, default_image_formats=None) -> None:
+    @staticmethod
+    def read_config_image_format(config: Dict[str, str]) -> Optional[ImageFormat]:
+        str_image_format = config.get("image-format") or config.get("type")
+        if not str_image_format:
+            return None
+
+        image_format = STR_TO_IMAGE_FORMAT.get(str_image_format)
+        if image_format:
+            return image_format
+
+        raise xs_errors.XenError('VDIType', opterr=f'Unknown image format `{str_image_format}`')
+
+    def _init_image_formats(
+        self,
+        *,
+        preferred_image_formats = DEFAULT_PREFERRED_IMAGE_FORMATS,
+        supported_image_formats = DEFAULT_SUPPORTED_IMAGE_FORMATS
+    ) -> None:
         self.preferred_image_formats = parseImageFormats(
             self.dconf and self.dconf.get('preferred-image-formats'),
-            default_image_formats or DEFAULT_IMAGE_FORMATS
+            preferred_image_formats,
+            supported_image_formats
         )
+        self.supported_image_formats = supported_image_formats
+
+    def _resolve_vdi_type_from_image_format(self, image_format: ImageFormat) -> str:
+        if image_format in self.supported_image_formats:
+            return getVdiTypeFromImageFormat(image_format)
+        raise xs_errors.XenError('VDIType', opterr=f'Unsupported image format `{image_format}`')
 
     def _get_snap_vdi_type(self, vdi_type: str, size: int) -> str:
         if VdiType.isCowImage(vdi_type):

--- a/drivers/cowutil.py
+++ b/drivers/cowutil.py
@@ -45,16 +45,20 @@ STR_TO_IMAGE_FORMAT: Final = {v: k for k, v in IMAGE_FORMAT_TO_STR.items()}
 
 # ------------------------------------------------------------------------------
 
-def parseImageFormats(str_formats: Optional[str], default_formats: List[ImageFormat]) -> List[ImageFormat]:
+def parseImageFormats(
+    str_formats: Optional[str],
+    default_formats: List[ImageFormat],
+    supported_formats: List[ImageFormat]
+) -> List[ImageFormat]:
+    default_formats = [f for f in default_formats if f in supported_formats]
+
     if not str_formats:
         return default_formats
 
-    entries = [entry.strip() for entry in str_formats.split(",")]
-
     image_formats: List[ImageFormat] = []
-    for entry in entries:
-        image_format = STR_TO_IMAGE_FORMAT.get(entry)
-        if image_format and image_format not in image_formats:
+    for entry in str_formats.split(","):
+        image_format = STR_TO_IMAGE_FORMAT.get(entry.strip())
+        if image_format in supported_formats and image_format not in image_formats:
             image_formats.append(image_format)
 
     if image_formats:


### PR DESCRIPTION
Before this change it was possible to create QCOW2 images on LINSTOR SRs using a forced "type" or "image-format".