### PR TITLE
fix(linstor): fail snapshot on coalesce race condition

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -560,23 +560,21 @@ class LinstorSR(SR.SR):
                 opterr='Redundancy greater than host count'
             )
 
-        xenapi = self.session.xenapi
-        srs = xenapi.SR.get_all_records_where(
-            'field "type" = "{}"'.format(self.DRIVER_TYPE)
-        )
-        srs = dict([e for e in srs.items() if e[1]['uuid'] != self.uuid])
+        srs = util.get_linstor_srs(self.session)
+        try:
+            srs.pop(self.uuid)
+        except KeyError:
+            # We cannot guarantee that the new SR key will be there even it should be the case.
+            pass
 
-        for sr in srs.values():
-            for pbd in sr['PBDs']:
-                device_config = xenapi.PBD.get_device_config(pbd)
-                group_name = device_config.get('group-name')
-                if group_name and group_name == self._group_name:
-                    raise xs_errors.XenError(
-                        'LinstorSRCreate',
-                        opterr='group name must be unique, already used by PBD {}'.format(
-                            xenapi.PBD.get_uuid(pbd)
-                        )
-                    )
+        pbd_uuid = util.find_pbd_uuid_from_dconf_value(
+            self.session, srs, "group-name", self._group_name, LinstorVolumeManager.build_group_name
+        )
+        if pbd_uuid:
+            raise xs_errors.XenError(
+                'LinstorSRCreate',
+                opterr=f"group name must be unique, already used by PBD {pbd_uuid}"
+            )
 
         if srs:
             raise xs_errors.XenError(
@@ -1870,7 +1868,8 @@ class LinstorVDI(VDI.VDI):
             return self._attach_using_http_nbd()
 
         # Ensure we have a path...
-        self.sr._vhdutil.create_chain_paths(self.uuid, readonly=not writable)
+        chain = self.sr._vhdutil.create_chain_paths(self.uuid, not writable, cleanup.LinstorSR.abort_gc_from_openers_vdi)
+        chain.close()
 
         self.attached = True
         return VDI.VDI.attach(self, self.sr.uuid, self.uuid)
@@ -2414,7 +2413,8 @@ class LinstorVDI(VDI.VDI):
             raise xs_errors.XenError('SnapshotChainTooLong')
 
         # Ensure we have a valid path if we don't have a local diskful.
-        self.sr._vhdutil.create_chain_paths(self.uuid, readonly=True)
+        chain = self.sr._vhdutil.create_chain_paths(self.uuid, True, cleanup.LinstorSR.abort_gc_from_openers_vdi)
+        chain.close()
 
         volume_path = self.path
         if not util.pathexists(volume_path):

--- a/drivers/VDI.py
+++ b/drivers/VDI.py
@@ -123,14 +123,8 @@ class VDI(object):
 
     @staticmethod
     def from_uuid(session, vdi_uuid):
-
-        _VDI = session.xenapi.VDI
-        vdi_ref = _VDI.get_by_uuid(vdi_uuid)
-        sr_ref = _VDI.get_SR(vdi_ref)
-
-        _SR = session.xenapi.SR
-        sr_uuid = _SR.get_uuid(sr_ref)
-
+        vdi_ref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
+        sr_uuid = util.get_sr_from_vdi_ref(session, vdi_ref)
         sr = SR.SR.from_uuid(session, sr_uuid)
 
         sr.srcmd.params['vdi_ref'] = vdi_ref

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -72,6 +72,11 @@ POOL_SIZE_KEY = "mem-pool-size-rings"
 ENABLE_MULTIPLE_ATTACH = "/etc/xensource/allow_multiple_vdi_attach"
 NO_MULTIPLE_ATTACH = not (os.path.exists(ENABLE_MULTIPLE_ATTACH))
 
+TAP_CTL_ERROR_PATTERN = re.compile(
+    r"(?P<status>ERROR|SUCCESS)\s"
+    r"\[(?P<code>-?[0-9]+)\s-\s(?P<category>.+?)]:\s"
+    r"(?P<message>.*)\sReason:\s(?P<reason>.+)"
+)
 
 def locking(excType, override=True):
     def locking2(op):
@@ -425,8 +430,20 @@ class TapCtl(object):
         if cbtlog:
             args.extend(["-c", cbtlog])
 
-        # TODO: Handle issue.
-        cls._pread(args)
+        @retried(backoff=.5, limit=10)
+        def unpause():
+            drbd_path = _file
+            try:
+                cls._pread(args)
+            except TapCtl.CommandFailure as e:
+                match = TAP_CTL_ERROR_PATTERN.search(e.info.get("errmsg", ""))
+                if match and match.group("reason"):
+                    drbd_path = match.group("reason")
+                if e.get_error_code() in (errno.EROFS, errno.EMEDIUMTYPE) and Tapdisk.abort_linstor_gc(drbd_path):
+                    raise RetryLoop.TransientFailure(e)
+                raise
+
+        unpause()
 
     @classmethod
     def shutdown(cls, pid):
@@ -860,7 +877,7 @@ class Tapdisk(object):
 
     @classmethod
     def launch_on_tap(cls, blktap, path, _type, options):
-
+        drbd_path = path
         tapdisk = cls.find_by_path(path)
         if tapdisk:
             raise TapdiskExists(tapdisk)
@@ -879,10 +896,11 @@ class Tapdisk(object):
                             TapCtl.open(pid, minor, _type, path, options)
                             break
                         except TapCtl.CommandFailure as e:
-                            err = (
-                                'status' in e.info and e.info['status']
-                            ) or None
-                            if err in (errno.EROFS, errno.EMEDIUMTYPE) and cls.abort_linstor_gc(path):
+                            err = e.get_error_code()
+                            match = TAP_CTL_ERROR_PATTERN.search(e.info.get("errmsg", ""))
+                            if match and match.group("reason"):
+                                drbd_path = match.group("reason")
+                            if err in (errno.EROFS, errno.EMEDIUMTYPE) and cls.abort_linstor_gc(drbd_path):
                                 continue
 
                             if err in (errno.EIO, errno.EAGAIN, errno.EROFS, errno.EMEDIUMTYPE) and retry_open < 5:

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -55,7 +55,7 @@ from xmlrpc.client import ServerProxy, Transport
 from socket import socket, AF_UNIX, SOCK_STREAM
 
 try:
-    from linstorvolumemanager import log_drbd_openers
+    from linstorvolumemanager import get_controller_uri, get_all_volume_openers, LinstorVolumeManager
     LINSTOR_AVAILABLE = True
 except ImportError:
     LINSTOR_AVAILABLE = False
@@ -424,6 +424,8 @@ class TapCtl(object):
             args += ["-a", str(params)]
         if cbtlog:
             args.extend(["-c", cbtlog])
+
+        # TODO: Handle issue.
         cls._pread(args)
 
     @classmethod
@@ -820,6 +822,42 @@ class Tapdisk(object):
         except util.CommandException as e:
             util.logException(e)
 
+    @staticmethod
+    def abort_linstor_gc(drbd_path: str) -> bool:
+        if not LINSTOR_AVAILABLE or not drbd_path.startswith("/dev/drbd/by-res/xcp-volume-"):
+            return False
+
+        _, volume_name, _ = drbd_path.rsplit("/", 2)
+        group_name = LinstorVolumeManager.get_volume_group_name(volume_name)
+
+        openers = get_all_volume_openers(volume_name, "0")
+
+        session = XenAPI.xapi_local()
+        session.xenapi.login_with_password("root", "", "", "SM")
+        try:
+            srs = util.get_linstor_srs(session)
+            pbd_uuid = util.find_pbd_uuid_from_dconf_value(
+                session, srs, "group-name", group_name, LinstorVolumeManager.build_group_name
+            )
+            if pbd_uuid:
+                pbd_ref = session.xenapi.PBD.get_by_uuid(pbd_uuid)
+                pbd_rec = session.xenapi.PBD.get_record(pbd_ref)
+
+                sr_ref = pbd_rec["SR"]
+                sr_uuid = session.xenapi.SR.get_uuid(sr_ref)
+
+                import cleanup # pylint: disable=C0415
+                if cleanup.LinstorSR.abort_gc_from_openers_sr(sr_uuid, openers):
+                    return True
+            else:
+                util.SMlog(f"Unable to find PBD of LINSTOR group `{group_name}`...")
+
+            util.SMlog(f"Unable to run tapdisk, openers of DRBD resource `{drbd_path}`: {openers}")
+        finally:
+            session.xenapi.session.logout()
+
+        return False
+
     @classmethod
     def launch_on_tap(cls, blktap, path, _type, options):
 
@@ -844,13 +882,13 @@ class Tapdisk(object):
                             err = (
                                 'status' in e.info and e.info['status']
                             ) or None
-                            if err in (errno.EIO, errno.EROFS, errno.EAGAIN):
-                                if retry_open < 5:
-                                    retry_open += 1
-                                    time.sleep(1)
-                                    continue
-                                if LINSTOR_AVAILABLE and err == errno.EROFS:
-                                    log_drbd_openers(path)
+                            if err in (errno.EROFS, errno.EMEDIUMTYPE) and cls.abort_linstor_gc(path):
+                                continue
+
+                            if err in (errno.EIO, errno.EAGAIN, errno.EROFS, errno.EMEDIUMTYPE) and retry_open < 5:
+                                retry_open += 1
+                                time.sleep(1)
+                                continue
                             raise
                     try:
                         tapdisk = cls.__from_blktap(blktap)

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -18,7 +18,7 @@
 # Script to coalesce and garbage collect VHD-based SR's in the background
 #
 
-from sm_typing import Optional, override
+from sm_typing import Dict, Optional, override
 
 import os
 import os.path
@@ -56,8 +56,7 @@ try:
     from linstorjournaler import LinstorJournaler
     from linstorvhdutil import LinstorVhdUtil, MultiLinstorVhdUtil
     from linstorvolumemanager import get_controller_uri
-    from linstorvolumemanager import LinstorVolumeManager
-    from linstorvolumemanager import LinstorVolumeManagerError
+    from linstorvolumemanager import LinstorVolumeManager, LinstorVolumeManagerError, LinstorVolumeOpeners
     from linstorvolumemanager import PERSISTENT_PREFIX as LINSTOR_PERSISTENT_PREFIX
 
     LINSTOR_AVAILABLE = True
@@ -3666,16 +3665,56 @@ class LinstorSR(SR):
 
     def _checkSlaves(self, vdi):
         try:
-            all_openers = self._linstor.get_volume_openers(vdi.uuid)
-            for openers in all_openers.values():
-                for opener in openers.values():
+            openers = self._linstor.get_volume_openers(vdi.uuid)
+            for host_openers in openers.values():
+                for opener in host_openers.values():
                     if opener['process-name'] != 'tapdisk':
                         raise util.SMException(
-                            'VDI {} is in use: {}'.format(vdi.uuid, all_openers)
+                            'VDI {} is in use: {}'.format(vdi.uuid, openers)
                         )
         except LinstorVolumeManagerError as e:
             if e.code != LinstorVolumeManagerError.ERR_VOLUME_NOT_EXISTS:
                 raise
+
+    @classmethod
+    def abort_gc_from_openers_vdi(cls, vdi_uuid: str, openers: "LinstorVolumeOpeners") -> bool:
+        return cls._abort_gc_from_openers(vdi_uuid, True, openers)
+
+    @classmethod
+    def abort_gc_from_openers_sr(cls, sr_uuid: str, openers: "LinstorVolumeOpeners") -> bool:
+        return cls._abort_gc_from_openers(sr_uuid, False, openers)
+
+    @staticmethod
+    def _abort_gc_from_openers(uuid: str, is_vdi_uuid: bool, openers: "LinstorVolumeOpeners") -> bool:
+        from linstorvhdutil import MANAGER_PLUGIN
+
+        node_name = None
+
+        for host_openers in openers.values():
+            for hostname, opener in host_openers.items():
+                # Not the most accurate check but it works...
+                # `vhd-util` is probably prefixed with a "+" which is ignored here.
+                if not opener["process-name"].endswith("vhd-util") or "coalesce" not in opener["cmdline"]:
+                    continue
+
+                if not node_name:
+                    import socket
+                    node_name = socket.gethostname()
+
+                if node_name == hostname:
+                    continue
+
+                session = XAPI.getSession()
+                try:
+                    sr_uuid = util.get_sr_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
+                    util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
+                    return util.strtobool(session.xenapi.host.call_plugin(
+                        util.get_master_ref(session), MANAGER_PLUGIN, "abortGc", {"srUuid": sr_uuid}
+                    ))
+                finally:
+                    session.xenapi.session.logout()
+        return False
+
 
 
 ################################################################################

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -3704,15 +3704,16 @@ class LinstorSR(SR):
                 if node_name == hostname:
                     continue
 
-                session = XAPI.getSession()
-                try:
-                    sr_uuid = util.get_sr_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
-                    util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
-                    return util.strtobool(session.xenapi.host.call_plugin(
-                        util.get_master_ref(session), MANAGER_PLUGIN, "abortGc", {"srUuid": sr_uuid}
-                    ))
-                finally:
-                    session.xenapi.session.logout()
+                with util.timeout(1):
+                    session = XAPI.getSession()
+                    try:
+                        sr_uuid = util.get_sr_from_vdi_uuid(session, uuid) if is_vdi_uuid else uuid
+                        util.SMlog(f"LINSTOR volume is coalescing on `{sr_uuid}`. We're going to interrupt the GC...")
+                        return util.strtobool(session.xenapi.host.call_plugin(
+                            util.get_master_ref(session), MANAGER_PLUGIN, "abortGc", {"srUuid": sr_uuid}
+                        ))
+                    finally:
+                        session.xenapi.session.logout()
         return False
 
 

--- a/drivers/linstor-manager
+++ b/drivers/linstor-manager
@@ -390,6 +390,19 @@ def destroy(session, args):
     return str(False)
 
 
+def abort_gc(session, args):
+    try:
+        sr_uuid = args['srUuid']
+
+        import cleanup
+        cleanup.abort(sr_uuid)
+
+        return str(True)
+    except Exception as e:
+        util.SMlog('linstor-manager:abort_gc error: {}'.format(e))
+    return str(False)
+
+
 def check(session, args):
     try:
         device_path = args['devicePath']
@@ -1236,6 +1249,7 @@ if __name__ == '__main__':
         'attach': attach,
         'detach': detach,
         'destroy': destroy,
+        'abortGc': abort_gc,
 
         # vhdutil wrappers called by linstorvhdutil.
         # Note: When a VHD is open in RO mode (so for all vhdutil getters),

--- a/drivers/linstorjournaler.py
+++ b/drivers/linstorjournaler.py
@@ -153,7 +153,7 @@ class LinstorJournaler:
                         'Unable to find controller uri...'
                     )
             return linstor.KV(
-                LinstorVolumeManager._build_group_name(group_name),
+                LinstorVolumeManager.build_group_name(group_name),
                 uri=uri,
                 namespace=namespace
             )

--- a/drivers/linstorvhdutil.py
+++ b/drivers/linstorvhdutil.py
@@ -14,10 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from sm_typing import List, override
+from sm_typing import Any, Callable, Dict, IO, List, Optional, override
 
 from linstorjournaler import LinstorJournaler
-from linstorvolumemanager import LinstorVolumeManager
+from linstorvolumemanager import LinstorVolumeManager, LinstorVolumeOpeners
 
 from concurrent.futures import ThreadPoolExecutor
 import base64
@@ -168,47 +168,74 @@ def linstormodifier():
 class LinstorVhdUtil:
     MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024  # Max VHD size.
 
+    class Chain(object):
+        def __init__(self, files: List[IO], leaf_path: str):
+            self._files = files
+            self._leaf_path = leaf_path
+
+        @property
+        def leaf_path(self) -> str:
+            return self._leaf_path
+
+        def close(self) -> None:
+            for file in self._files:
+                try:
+                    file.close()
+                except Exception: # pylint: disable = W0718
+                    pass
+
     def __init__(self, session, linstor):
         self._session = session
         self._linstor = linstor
 
-    def create_chain_paths(self, vdi_uuid, readonly=False):
+    def create_chain_paths(
+        self,
+        vdi_uuid: str,
+        readonly=False,
+        cb_openers: Optional[Callable[[str, LinstorVolumeOpeners], Any]] = None
+    ) -> Chain:
         # OPTIMIZE: Add a limit_to_first_allocated_block param to limit vhdutil calls.
         # Useful for the snapshot code algorithm.
 
-        leaf_vdi_path = self._linstor.get_device_path(vdi_uuid)
-        path = leaf_vdi_path
-        while True:
-            if not util.pathexists(path):
-                raise xs_errors.XenError(
-                    'VDIUnavailable', opterr='Could not find: {}'.format(path)
-                )
+        files = []
 
-            # Diskless path can be created on the fly, ensure we can open it.
-            def check_volume_usable():
-                while True:
-                    try:
-                        with open(path, 'r' if readonly else 'r+'):
-                            pass
-                    except IOError as e:
-                        if e.errno == errno.ENODATA:
-                            time.sleep(2)
-                            continue
-                        if e.errno == errno.EROFS or e.errno == errno.EMEDIUMTYPE:
-                            util.SMlog('Volume not attachable because used. Openers: {}'.format(
-                                self._linstor.get_volume_openers(vdi_uuid)
-                            ))
-                        raise
+        leaf_path = self._linstor.get_device_path(vdi_uuid)
+        path = leaf_path
+        try:
+            while True:
+                if not util.pathexists(path):
+                    raise xs_errors.XenError(
+                        'VDIUnavailable', opterr='Could not find: {}'.format(path)
+                    )
+
+                # Diskless path can be created on the fly, ensure we can open it.
+                def check_volume_usable():
+                    while True:
+                        try:
+                            files.append(open(path, 'r' if readonly else 'r+'))
+                        except OSError as e:
+                            if e.errno == errno.ENODATA:
+                                time.sleep(2)
+                                continue
+                            if e.errno in (errno.EROFS, errno.EMEDIUMTYPE):
+                                openers = self._linstor.get_volume_openers(vdi_uuid)
+                                util.SMlog(f'Volume not attachable because used. Openers: {openers}')
+                                if cb_openers:
+                                    cb_openers(vdi_uuid, openers)
+                            raise
+                        break
+                util.retry(check_volume_usable, 15, 2)
+
+                vdi_uuid = self.get_vhd_info(vdi_uuid).parentUuid
+                if not vdi_uuid:
                     break
-            util.retry(check_volume_usable, 15, 2)
+                path = self._linstor.get_device_path(vdi_uuid)
+                readonly = True  # Non-leaf is always readonly.
+        except Exception as e:
+            self.Chain(files, leaf_path).close()
+            raise e
 
-            vdi_uuid = self.get_vhd_info(vdi_uuid).parentUuid
-            if not vdi_uuid:
-                break
-            path = self._linstor.get_device_path(vdi_uuid)
-            readonly = True  # Non-leaf is always readonly.
-
-        return leaf_vdi_path
+        return self.Chain(files, leaf_path)
 
     # --------------------------------------------------------------------------
     # Getters: read locally and try on another host in case of failure.
@@ -557,7 +584,7 @@ class LinstorVhdUtil:
         # B.3. Call!
         def remote_call():
             try:
-                all_openers = self._linstor.get_volume_openers(openers_uuid)
+                openers = self._linstor.get_volume_openers(openers_uuid)
             except Exception as e:
                 raise xs_errors.XenError(
                     'VDIUnavailable',
@@ -566,8 +593,8 @@ class LinstorVhdUtil:
                 )
 
             no_host_found = True
-            for hostname, openers in all_openers.items():
-                if not openers:
+            for hostname, host_openers in openers.items():
+                if not host_openers:
                     continue
 
                 host_ref = self._find_host_ref_from_hostname(hosts, hostname)

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -19,6 +19,7 @@ from sm_typing import (
     Any,
     Dict,
     List,
+    cast,
     override,
 )
 
@@ -59,10 +60,12 @@ DRBD_BY_RES_PATH = '/dev/drbd/by-res/'
 
 PLUGIN = 'linstor-manager'
 
+LinstorLocalVolumeOpeners = Dict[str, Dict[str, Any]]
+LinstorVolumeOpeners = Dict[str, LinstorLocalVolumeOpeners]
 
 # ==============================================================================
 
-def get_local_volume_openers(resource_name, volume):
+def get_local_volume_openers(resource_name, volume) -> LinstorLocalVolumeOpeners:
     if not resource_name or volume is None:
         raise Exception('Cannot get DRBD openers without resource name and/or volume.')
 
@@ -85,14 +88,22 @@ def get_local_volume_openers(resource_name, volume):
         process_name = groups[0]
         pid = groups[1]
         open_duration_ms = groups[2]
+
+        try:
+            cmdline = util.get_process_cmdline(int(pid))
+        except Exception as e:
+            util.SMlog(f"Failed to get command line of `{pid}`: {e}")
+            cmdline = []
+
         result[pid] = {
             'process-name': process_name,
-            'open-duration': open_duration_ms
+            'open-duration': open_duration_ms,
+            'cmdline': cmdline
         }
 
-    return json.dumps(result)
+    return cast(LinstorLocalVolumeOpeners, json.dumps(result))
 
-def get_all_volume_openers(resource_name, volume):
+def get_all_volume_openers(resource_name, volume) -> LinstorVolumeOpeners:
     PLUGIN_CMD = 'getDrbdOpeners'
 
     volume = str(volume)
@@ -384,7 +395,7 @@ class LinstorVolumeManager(object):
         self._base_group_name = group_name
 
         # Ensure group exists.
-        group_name = self._build_group_name(group_name)
+        group_name = self.build_group_name(group_name)
         groups = self._linstor.resource_group_list_raise([group_name]).resource_groups
         if not groups:
             raise LinstorVolumeManagerError(
@@ -1170,7 +1181,7 @@ class LinstorVolumeManager(object):
 
         return states
 
-    def get_volume_openers(self, volume_uuid):
+    def get_volume_openers(self, volume_uuid) -> LinstorVolumeOpeners:
         """
         Get openers of a volume.
         :param str volume_uuid: The volume uuid to monitor.
@@ -1803,7 +1814,28 @@ class LinstorVolumeManager(object):
         :return: List of group names.
         :rtype: list
         """
-        return [cls._build_group_name(base_name), cls._build_ha_group_name(base_name)]
+        return [cls.build_group_name(base_name), cls._build_ha_group_name(base_name)]
+
+    @classmethod
+    def get_volume_group_name(cls, volume_name):
+        """
+        Get the group name associated with a volume.
+        :param str volume_name: The volume name to find.
+        :return: A group name.
+        :rtype: str
+        """
+
+        lin = cls._create_linstor_instance(uri=None)
+        try:
+            for dfn in lin.resource_dfn_list_raise(
+                query_volume_definitions=False,
+                filter_by_resource_definitions=[volume_name]
+            ).resource_definitions:
+                return dfn.resource_group_name
+        finally:
+            lin.disconnect()
+
+        return ''
 
     @classmethod
     def create_sr(cls, group_name, ips, redundancy, thin_provisioning, logger=default_logger.__func__):
@@ -1873,7 +1905,7 @@ class LinstorVolumeManager(object):
 
         driver_pool_name = group_name
         base_group_name = group_name
-        group_name = cls._build_group_name(group_name)
+        group_name = cls.build_group_name(group_name)
         storage_pool_name = group_name
         pools = lin.storage_pool_list_raise(filter_by_stor_pools=[storage_pool_name]).storage_pools
         if pools:
@@ -2469,13 +2501,13 @@ class LinstorVolumeManager(object):
             )
 
         # If force is used, ensure there is no opener.
-        all_openers = get_all_volume_openers(resource_name, '0')
-        for openers in all_openers.values():
-            if openers:
+        openers = get_all_volume_openers(resource_name, '0')
+        for host_openers in openers.values():
+            if host_openers:
                 self._mark_resource_cache_as_dirty()
                 raise LinstorVolumeManagerError(
                     'Could not force destroy resource `{}` from SR `{}`: {} (openers=`{}`)'
-                    .format(resource_name, self._group_name, error_str, all_openers)
+                    .format(resource_name, self._group_name, error_str, openers)
                 )
 
         # Maybe the resource is blocked in primary mode. DRBD/LINSTOR issue?
@@ -3061,7 +3093,7 @@ class LinstorVolumeManager(object):
         return util.retry(destroy, maxretry=10)
 
     @classmethod
-    def _build_group_name(cls, base_name):
+    def build_group_name(cls, base_name):
         # If thin provisioning is used we have a path like this:
         # `VG/LV`. "/" is not accepted by LINSTOR.
         return '{}{}'.format(cls.PREFIX_SR, base_name.replace('/', '_'))

--- a/drivers/tapdisk-pause
+++ b/drivers/tapdisk-pause
@@ -168,7 +168,14 @@ class Tapdisk:
                 group_name,
                 logger=util.SMlog
             )
-            device_path = LinstorVhdUtil(session, linstor).create_chain_paths(self.vdi_uuid)
+
+            import cleanup
+            chain = LinstorVhdUtil(session, linstor).create_chain_paths(
+                self.vdi_uuid, False, cleanup.LinstorSR.abort_gc_from_openers_vdi
+            )
+
+            device_path = chain.leaf_path
+            chain.close()
 
             if realpath != device_path:
                 util.SMlog(

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -16,6 +16,8 @@
 # Miscellaneous utility functions
 #
 
+from sm_typing import List
+
 import os
 import re
 import sys
@@ -1230,6 +1232,15 @@ def _getVDIs(srobj):
     return VDIs
 
 
+def get_sr_from_vdi_ref(session, vdi_ref: str) -> str:
+    sr_ref = session.xenapi.VDI.get_SR(vdi_ref)
+    return session.xenapi.SR.get_uuid(sr_ref)
+
+
+def get_sr_from_vdi_uuid(session, vdi_uuid: str) -> str:
+    return get_sr_from_vdi_ref(session, session.xenapi.VDI.get_by_uuid(vdi_uuid))
+
+
 def _getVDI(srobj, vdi_uuid):
     vdi = srobj.session.xenapi.VDI.get_by_uuid(vdi_uuid)
     ref = srobj.session.xenapi.VDI.get_record(vdi)
@@ -1502,6 +1513,17 @@ def pid_is_alive(pid):
         if e.errno == errno.EPERM:
             return True
         return False
+
+
+def get_process_cmdline(pid: int) -> List[str]:
+    try:
+        with open(os.path.join('/proc', str(pid), 'cmdline'), 'rb') as f:
+            line = f.read().split(b'\0')
+        return [arg.decode() for arg in line]
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        return []
 
 
 # Looks at /proc and figures either
@@ -2176,3 +2198,25 @@ def conditional_decorator(decorator, condition):
             return func
         return decorator(func)
     return wrapper
+
+
+def get_srs_from_type(session, type):
+    srs = session.xenapi.SR.get_all_records_where(f"field \"type\" = \"{type}\"")
+    return {sr["uuid"]: sr for sr in srs.values()}
+
+
+def get_linstor_srs(session):
+    import LinstorSR # pylint: disable=C0415
+    return get_srs_from_type(session, LinstorSR.LinstorSR.DRIVER_TYPE)
+
+
+def find_pbd_uuid_from_dconf_value(session, srs, key, value, value_modifier = None):
+    for sr in srs.values():
+        for pbd_ref in sr["PBDs"]:
+            device_config = session.xenapi.PBD.get_device_config(pbd_ref)
+            cur_value = device_config.get(key)
+            if value_modifier:
+                cur_value = value_modifier(cur_value)
+            if cur_value and cur_value == value:
+                return session.xenapi.PBD.get_uuid(pbd_ref)
+    return None

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -18,6 +18,7 @@
 
 from sm_typing import List
 
+import contextlib
 import os
 import re
 import sys
@@ -398,6 +399,17 @@ def ioretry_stat(path, maxretry=IORETRY_MAX):
         retries += 1
     raise CommandException(errno.EIO, "os.statvfs")
 
+@contextlib.contextmanager
+def timeout(seconds: int):
+    def handle_timeout(_signum, _frame):
+        raise TimeoutError("Timed out after %d seconds" % seconds)
+
+    signal.signal(signal.SIGALRM, handle_timeout)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
 
 def sr_get_capability(sr_uuid, session=None):
     result = []

--- a/sm_typing/__init__.py
+++ b/sm_typing/__init__.py
@@ -1,6 +1,8 @@
 import typing
 from typing import *
 
+from typing import IO
+
 if not hasattr(typing, 'override'):
     def override(method): # type: ignore
         try:


### PR DESCRIPTION
This PR is a candidate solution for the coalesce race condition. Currently it ends up leaving the VM disk as paused. The solution proposed by Ronan (first commit) ends up causing a deadlock which hangs the snapshot operation. This solution make the snapshot gracefully fail after a few abort tries.

Aborts GC when failing to activate the whole chain or
open/unpause a VDI because one in the chain is held open in linstor
because of the GC coalescing. 

However The GC won't abort due to a deadlock on the SR lock, this causes
the abort function to hang. Adding a timeout on the abort operation
raises an exception and causes a fail instead of hanging.