### PR TITLE
fix(cleanup): check earlier if a chain is attached on multiple hosts

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -666,11 +666,20 @@ class VDI(object):
 
     def isCoalesceable(self):
         """A VDI is coalesceable if it has no siblings and is not a leaf"""
-        return not self.scanError and \
-                self.parent and \
-                len(self.parent.children) == 1 and \
-                self.isHidden() and \
-                len(self.children) > 0
+        return (
+            not self.scanError and
+            self.parent and
+            len(self.parent.children) == 1 and
+            self.isHidden() and
+            len(self.children) > 0 and (
+                # Conditions below are Qcow2 specific:
+                # A Qcow2 chain can't be coalesce with more than one leaf attached.
+                # Put it another way, Qcow2 leaves activated on multiple hosts must
+                # prevent the coalesce of the chain.
+                self.vdi_type != VdiType.QCOW2 or
+                (self.vdi_type == VdiType.QCOW2 and len(self.sr.hasLeavesAttachedOn(self)) <= 1)
+            )
+        )
 
     def isLeafCoalesceable(self):
         """A VDI is leaf-coalesceable if it has no siblings and is a leaf"""
@@ -2521,7 +2530,7 @@ class SR(object):
     def cleanupCache(self, maxAge=-1) -> int:
         return 0
 
-    def _hasLeavesAttachedOn(self, vdi: VDI):
+    def hasLeavesAttachedOn(self, vdi: VDI):
         leaves = vdi.getAllLeaves()
         leaves_vdi = [leaf.uuid for leaf in leaves]
         return util.get_hosts_attached_on_with_vdi_uuid(self.xapi.session, leaves_vdi)
@@ -2559,11 +2568,13 @@ class SR(object):
             self._create_running_file(vdi)
 
             self.journaler.create(vdi.JRN_COALESCE, vdi.uuid, "1")
-            host_refs = self._hasLeavesAttachedOn(vdi)
-            #TODO: this check of multiple host_refs should be done earlier in `is_coalesceable` to avoid stopping this late every time
-            if len(host_refs) > 1:
+            host_refs = self.hasLeavesAttachedOn(vdi)
+            # This check of multiple host_refs was done earlier in `isCoalesceable` but
+            # we recheck here to be sure another leaf wasn't activated in the meantime.
+            if vdi.cowutil.isCoalesceableOnRemote() and len(host_refs) > 1:
                 Util.log("Not coalesceable, chain activated more than once")
-                raise Exception("Not coalesceable, chain activated more than once") #TODO: Use correct error
+                Util.log(f"VDI '{vdi.uuid}' has leaves attached on {host_refs}")
+                raise Exception("Not coalesceable, chain activated more than once")
 
             try:
                 if host_refs and vdi.cowutil.isCoalesceableOnRemote():
@@ -2903,7 +2914,7 @@ class SR(object):
         self._prepareCoalesceLeaf(vdi)
         vdi.parent._setHidden(False)
         vdi.parent._increaseSizeVirt(vdi.sizeVirt, False)
-        host_refs = self._hasLeavesAttachedOn(vdi) if coalesce_on_remote else None
+        host_refs = self.hasLeavesAttachedOn(vdi) if coalesce_on_remote else None
         if host_refs:
             util.fistpoint.activate("LVHDRT_coaleaf_before_coalesce", self.uuid)
             _, host_ref = next(iter(host_refs.items()))


### PR DESCRIPTION
The check is made in `onCoalesceable` to exclude the chain from the candidates.