### PR TITLE
fix(FileSR) Add 'image-format' to sm_config_override in load of FileVDI

### DIFF
--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -543,6 +543,7 @@ class FileVDI(VDI.VDI):
                 self.sm_config_override = {'vhd-parent': self.parent}
             else:
                 self.sm_config_override = {'vhd-parent': None}
+            self.sm_config_override["image-format"] = getImageStringFromVdiType(self.vdi_type)
             return
 
         try:
@@ -593,6 +594,7 @@ class FileVDI(VDI.VDI):
                 else:
                     self.parent = ""
                     self.sm_config_override = {'vhd-parent': None}
+                self.sm_config_override["image-format"] = getImageStringFromVdiType(self.vdi_type)
                 self.size = image_info.sizeVirt
                 self.hidden = image_info.hidden
                 if self.hidden:


### PR DESCRIPTION
_db_update_sm_config function removed the image format value
Keep 'image-format' value like it's done for 'vhd-parend' in load of FileVDI