### PR TITLE
feat(linstor): backup DB on major ops and regularly on check_sr (rebirth)

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -1590,8 +1590,7 @@ class LinstorSR(SR.SR):
         """
         Generate a new database backup file.
         This operation should not prevent the underlying action to be successful.
-        Hence all Exceptions are caught and re-raised only if asked to.
-        delay: skip backup if the last one was generated less than delay seconds ago.
+        Hence all Exceptions are caught and logged.
         """
         if not self._linstor:
             self._reconnect()
@@ -1599,7 +1598,7 @@ class LinstorSR(SR.SR):
             self._linstor.database_backup(name)
         except Exception as e:
             util.SMlog(
-                "[database_backup] Error during creation: {}".format(e),
+                f"[database_backup] Error during creation: {e}",
                 priority=util.LOG_ERR,
             )
 

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -818,6 +818,11 @@ class LinstorSR(SR.SR):
         return self._is_master
 
     @override
+    def check_sr(self, sr_uuid) -> None:
+        self.database_backup("auto", delay=3600)
+
+
+    @override
     @_locked_load
     def vdi(self, uuid) -> VDI.VDI:
         return LinstorVDI(self, uuid)
@@ -1570,6 +1575,11 @@ class LinstorSR(SR.SR):
         util.SMlog('Kicking GC')
         cleanup.start_gc_service(self.uuid)
 
+    def database_backup(self, name="", *, delay=0):
+        if not self._linstor:
+            self._reconnect()
+        self._linstor.database_backup(name, delay=delay)
+
 # ==============================================================================
 # LinstorSr VDI
 # ==============================================================================
@@ -1753,6 +1763,8 @@ class LinstorVDI(VDI.VDI):
         self.ref = self._db_introduce()
         self.sr._update_stats(self.size)
 
+        self.sr.database_backup("create")
+
         return VDI.VDI.get_params(self)
 
     @override
@@ -1800,7 +1812,8 @@ class LinstorVDI(VDI.VDI):
         # TODO: Check size after delete.
         self.sr._update_stats(-self.size)
         self.sr._kick_gc()
-        return super(LinstorVDI, self).delete(sr_uuid, vdi_uuid, data_only)
+        super(LinstorVDI, self).delete(sr_uuid, vdi_uuid, data_only)
+        self.sr.database_backup("delete")
 
     @override
     def attach(self, sr_uuid, vdi_uuid) -> str:
@@ -2382,6 +2395,7 @@ class LinstorVDI(VDI.VDI):
         finally:
             self.disable_leaf_on_secondary(vdi_uuid, secondary=secondary)
             blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)
+            self.sr.database_backup("snapshot")
 
     def _snapshot(self, snap_type, cbtlog=None, cbt_consistency=None):
         util.SMlog(

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -819,11 +819,19 @@ class LinstorSR(SR.SR):
 
     @override
     def check_sr(self, sr_uuid) -> None:
-        # Automatic backup if there were no backups for the last hour.
-        # Let it fail if needed, so full Traceback is on SMLog.
-        # Launch it only if we are on the controller.
-        self.database_backup("auto", delay=3600, fail=True, controller=True)
-
+        # Only applied on the Linstor Controller, for various reasons.
+        if not LinstorVolumeManager.is_controller():
+            return
+        # Start database invalidation.
+        # Needs access to backup files, available only on the Controller.
+        LinstorVolumeManager.database_invalidation()
+        # check_sr is launched on *all* hosts, but it turns out that
+        # we do not want all of them to blindly generate concurrencing backups.
+        # Hence we must choose one, either one is good, but there must be only one.
+        # Apply throttling: only backup if last one is >1h old.
+        # Needs access to backup files, available only on the Controller.
+        if LinstorVolumeManager.database_backup_age() > 3600:
+            self.database_backup("auto")
 
     @override
     @_locked_load
@@ -1578,30 +1586,22 @@ class LinstorSR(SR.SR):
         util.SMlog('Kicking GC')
         cleanup.start_gc_service(self.uuid)
 
-    def database_backup(self, name="", *, delay=0, fail=False, controller=False):
-        """Generate a new database backup file.
+    def database_backup(self, name=""):
+        """
+        Generate a new database backup file.
         This operation should not prevent the underlying action to be successful.
         Hence all Exceptions are caught and re-raised only if asked to.
         delay: skip backup if the last one was generated less than delay seconds ago.
-        fail: If fail is True, caught Exception are raised after being logged in SMlog.
-        controller: operate only if the current host is the Linstor Controller.
-         > This will trigger controller-only operations like retention and validation.
         """
         if not self._linstor:
             self._reconnect()
-        if controller and not self._linstor.is_controller():
-            return
         try:
-            if controller:
-                self._linstor.database_invalidation()
-            self._linstor.database_backup(name, delay=delay)
+            self._linstor.database_backup(name)
         except Exception as e:
             util.SMlog(
                 "[database_backup] Error during creation: {}".format(e),
                 priority=util.LOG_ERR,
             )
-            if fail:
-                raise
 
 # ==============================================================================
 # LinstorSr VDI

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -819,7 +819,10 @@ class LinstorSR(SR.SR):
 
     @override
     def check_sr(self, sr_uuid) -> None:
-        self.database_backup("auto", delay=3600)
+        # Automatic backup if there were no backups for the last hour.
+        # Let it fail if needed, so full Traceback is on SMLog.
+        # Launch it only if we are on the controller.
+        self.database_backup("auto", delay=3600, fail=True, controller=True)
 
 
     @override
@@ -1575,10 +1578,28 @@ class LinstorSR(SR.SR):
         util.SMlog('Kicking GC')
         cleanup.start_gc_service(self.uuid)
 
-    def database_backup(self, name="", *, delay=0):
+    def database_backup(self, name="", *, delay=0, fail=False, controller=False):
+        """Generate a new database backup file.
+        This operation should not prevent the underlying action to be successful.
+        Hence all Exceptions are caught and re-raised only if asked to.
+        controller: operate only if the current host is the Linstor Controller.
+        """
         if not self._linstor:
             self._reconnect()
-        self._linstor.database_backup(name, delay=delay)
+        if controller:
+            if self._linstor.is_controller():
+                self._linstor.database_invalidation()
+            else:
+                return
+        try:
+            self._linstor.database_backup(name, delay=delay)
+        except Exception as e:
+            util.SMlog(
+                "[database_backup] Error during creation: {}".format(e),
+                priority=util.LOG_ERR,
+            )
+            if fail:
+                raise
 
 # ==============================================================================
 # LinstorSr VDI

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -16,7 +16,7 @@
 
 from sm_typing import Any, Optional, override, Literal
 
-from constants import CBTLOG_TAG
+from constants import CBTLOG_TAG, LINSTOR_AUTO_BACKUP_DELAY
 
 try:
     from linstorcowutil import LinstorCowUtil, MultiLinstorCowUtil
@@ -824,7 +824,7 @@ class LinstorSR(SR.SR):
         # Applied only on the Linstor Controller, for reasons -> listed below.
         if not LinstorVolumeManager.is_controller():
             return
-        # Start database invalidation.
+        # Validate and clean previous backups if necessary.
         # -> Needs access to backup files, available only on the Controller.
         LinstorVolumeManager.database_invalidation()
         # check_sr is launched on *all* hosts, but it turns out that
@@ -832,7 +832,7 @@ class LinstorSR(SR.SR):
         # Hence we must choose one, either one is good, but there must be only one.
         # Apply throttling: only backup if last one is >1h old.
         # -> Needs access to backup files, available only on the Controller.
-        if LinstorVolumeManager.database_backup_age() > 3600:
+        if LinstorVolumeManager.get_database_backup_age() > LINSTOR_AUTO_BACKUP_DELAY:
             self.database_backup("auto")
 
     @override

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from sm_typing import Any, Optional, override
+from sm_typing import Any, Optional, override, Literal
 
 from constants import CBTLOG_TAG
 
@@ -819,17 +819,19 @@ class LinstorSR(SR.SR):
 
     @override
     def check_sr(self, sr_uuid) -> None:
-        # Only applied on the Linstor Controller, for various reasons.
+        # Note: check_sr is called on all hosts by the health check mechanism
+        # not by regular xapi calls such as scans.
+        # Applied only on the Linstor Controller, for reasons -> listed below.
         if not LinstorVolumeManager.is_controller():
             return
         # Start database invalidation.
-        # Needs access to backup files, available only on the Controller.
+        # -> Needs access to backup files, available only on the Controller.
         LinstorVolumeManager.database_invalidation()
         # check_sr is launched on *all* hosts, but it turns out that
         # we do not want all of them to blindly generate concurrencing backups.
         # Hence we must choose one, either one is good, but there must be only one.
         # Apply throttling: only backup if last one is >1h old.
-        # Needs access to backup files, available only on the Controller.
+        # -> Needs access to backup files, available only on the Controller.
         if LinstorVolumeManager.database_backup_age() > 3600:
             self.database_backup("auto")
 
@@ -1586,7 +1588,7 @@ class LinstorSR(SR.SR):
         util.SMlog('Kicking GC')
         cleanup.start_gc_service(self.uuid)
 
-    def database_backup(self, name=""):
+    def database_backup(self, name: Literal["auto", "create", "delete", "snapshot"]):
         """
         Generate a new database backup file.
         This operation should not prevent the underlying action to be successful.
@@ -1595,7 +1597,7 @@ class LinstorSR(SR.SR):
         if not self._linstor:
             self._reconnect()
         try:
-            self._linstor.database_backup(name)
+            self._linstor.database_backup(name)  # type: ignore
         except Exception as e:
             util.SMlog(
                 f"[database_backup] Error during creation: {e}",

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -826,7 +826,7 @@ class LinstorSR(SR.SR):
             return
         # Validate and clean previous backups if necessary.
         # -> Needs access to backup files, available only on the Controller.
-        LinstorVolumeManager.database_invalidation()
+        LinstorVolumeManager.database_backup_validate_and_prune()
         # check_sr is launched on *all* hosts, but it turns out that
         # we do not want all of them to blindly generate concurrencing backups.
         # Hence we must choose one, either one is good, but there must be only one.
@@ -1597,7 +1597,8 @@ class LinstorSR(SR.SR):
         if not self._linstor:
             self._reconnect()
         try:
-            self._linstor.database_backup(name)  # type: ignore
+            assert self._linstor
+            self._linstor.database_backup(name)
         except Exception as e:
             util.SMlog(
                 f"[database_backup] Error during creation: {e}",

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -1582,16 +1582,18 @@ class LinstorSR(SR.SR):
         """Generate a new database backup file.
         This operation should not prevent the underlying action to be successful.
         Hence all Exceptions are caught and re-raised only if asked to.
+        delay: skip backup if the last one was generated less than delay seconds ago.
+        fail: If fail is True, caught Exception are raised after being logged in SMlog.
         controller: operate only if the current host is the Linstor Controller.
+         > This will trigger controller-only operations like retention and validation.
         """
         if not self._linstor:
             self._reconnect()
-        if controller:
-            if self._linstor.is_controller():
-                self._linstor.database_invalidation()
-            else:
-                return
+        if controller and not self._linstor.is_controller():
+            return
         try:
+            if controller:
+                self._linstor.database_invalidation()
             self._linstor.database_backup(name, delay=delay)
         except Exception as e:
             util.SMlog(

--- a/drivers/constants.py
+++ b/drivers/constants.py
@@ -11,3 +11,5 @@ VG_PREFIX: Final = "VG_XenStorage-"
 # Ref counting for VDI's: we need a ref count for LV activation/deactivation
 # on the master.
 NS_PREFIX_LVM: Final = "lvm-"
+
+LINSTOR_AUTO_BACKUP_DELAY = 3600

--- a/drivers/constants.py
+++ b/drivers/constants.py
@@ -12,4 +12,5 @@ VG_PREFIX: Final = "VG_XenStorage-"
 # on the master.
 NS_PREFIX_LVM: Final = "lvm-"
 
+# Delay in seconds between two LINSTOR DB backups when launched by the check_sr helper.
 LINSTOR_AUTO_BACKUP_DELAY = 3600

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -33,6 +33,9 @@ import stat
 import time
 import util
 import uuid
+from datetime import datetime
+from pathlib import Path
+import contextlib
 
 # Persistent prefix to add to RAW persistent volumes.
 PERSISTENT_PREFIX = 'xcp-persistent-'
@@ -42,7 +45,12 @@ DATABASE_VOLUME_NAME = PERSISTENT_PREFIX + 'database'
 DATABASE_SIZE = 1 << 30  # 1GB.
 DATABASE_PATH = '/var/lib/linstor'
 DATABASE_MKFS = 'mkfs.ext4'
-
+DATABASE_BACKUP_DIR_MAIN = Path(DATABASE_PATH)
+DATABASE_BACKUP_DIR_SPARE = Path('/var/lib/linstor.d/db-backups')
+DATABASE_BACKUP_NAME_FORMAT = "linstor_database_backup-{}-{}"
+DATABASE_BACKUP_NAME_LATEST = "linstor_database_backup-latest.zip"
+DATABASE_BACKUP_RETENTION = 10
+DATABASE_BACKUP_DATE_FORMAT = "%Y%m%d_%H%M%S"
 LINSTOR_SATELLITE_PORT = 3366
 
 REG_DRBDADM_PRIMARY = re.compile("([^\\s]+)\\s+role:Primary")
@@ -1780,6 +1788,35 @@ class LinstorVolumeManager(object):
         """
         return self._request_database_path(self._linstor, activate=True)
 
+    def database_backup(self, name="", *, delay=0):
+        now = datetime.now()
+        # Throttling to avoid too many backups of the same kind on a short period
+        if delay:
+            _, date_latest = self._get_latest_database_backup(name)
+            if date_latest and ((now - date_latest).total_seconds() < delay):
+                return  # No backup for now
+
+        # Create new backup with link to latest
+        filename = DATABASE_BACKUP_NAME_FORMAT.format(now.strftime(DATABASE_BACKUP_DATE_FORMAT), name)
+        self._linstor.controller_backupdb(filename)
+        # Copy to secondary backup location
+        with contextlib.suppress(OSError):
+            os.makedirs(DATABASE_BACKUP_DIR_SPARE, mode=0o755, exist_ok=True)
+            shutil.copy2(
+                (DATABASE_BACKUP_DIR_MAIN / filename).with_suffix(".zip"),
+                DATABASE_BACKUP_DIR_SPARE,
+            )
+        for directory in (DATABASE_BACKUP_DIR_MAIN, DATABASE_BACKUP_DIR_SPARE):
+            # Remove and set latest
+            with contextlib.suppress(OSError):
+                (directory / DATABASE_BACKUP_NAME_LATEST).unlink()
+            os.link(str((directory / filename).with_suffix(".zip")),
+                    str((directory / DATABASE_BACKUP_NAME_LATEST)))
+            # Apply retention
+            for old_file, _ in self._get_sorted_database_backup(directory)[DATABASE_BACKUP_RETENTION:]:
+                os.unlink(old_file)
+        util.SMlog("[database_backup] Created: {}".format(filename))
+
     @classmethod
     def get_all_group_names(cls, base_name):
         """
@@ -2656,6 +2693,24 @@ class LinstorVolumeManager(object):
         properties = self._get_kv_cache()
         properties.namespace = self._build_volume_namespace(volume_uuid)
         return properties
+
+    def _list_database_backup(self, database_backup_dir, name="*"):
+        for path in database_backup_dir.glob(DATABASE_BACKUP_NAME_FORMAT.format(
+                "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]", name) + ".zip"):
+            try:
+                yield path, datetime.strptime(path.name.split("-")[1], DATABASE_BACKUP_DATE_FORMAT)
+            except (ValueError, IndexError):
+                continue
+
+    def _get_sorted_database_backup(self, database_backup_dir, name="*"):
+        return sorted(self._list_database_backup(database_backup_dir, name),
+                      reverse=True,
+                      key=lambda p: p[0].stat().st_mtime)
+
+    def _get_latest_database_backup(self, name="*"):
+        return max(self._list_database_backup(DATABASE_BACKUP_DIR_MAIN, name),
+                   default=(None, None),
+                   key=lambda p: p[0].stat().st_mtime)
 
     @classmethod
     def _build_sr_namespace(cls):

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -2711,18 +2711,18 @@ class LinstorVolumeManager(object):
 
     def _log_database_backup(self, date, name):
         """Log a database backup operation: "date name"
-        We cannot assume the pool-master is the same as the linstor-master,
-        this file is on the pool-master, and serves for the throttling."""
+        We cannot assume the Pool Master is the same as the Linstor Controller,
+        this file is on the Pool Master, and serves for the throttling."""
         os.makedirs(DATABASE_BACKUP_LOGDIR, mode=0o755, exist_ok=True)
         with open(DATABASE_BACKUP_LOGFILE, "a", encoding="utf8") as f:
-            f.write(f"{date} {name}\n")
+            f.write(f"{date} {name[:15]}\n")
 
     def _get_latest_logged_database_backup_date(self):
         # get last log line if it exists, and return the corresponding date
         try:
             with open(DATABASE_BACKUP_LOGFILE, "rb") as f:
-                # seek from the end, with 256 as a most-probable maximum line length
-                f.seek(-min(os.stat(DATABASE_BACKUP_LOGFILE).st_size, 256), os.SEEK_END)
+                # seek from the end, a line length can't be more than 32
+                f.seek(-min(os.stat(DATABASE_BACKUP_LOGFILE).st_size, 32), os.SEEK_END)
                 return f.read().decode().splitlines()[-1].split()[0]
         except FileNotFoundError:
             return "20000101_000000"

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -36,6 +36,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 import contextlib
+import zipfile
 
 # Persistent prefix to add to RAW persistent volumes.
 PERSISTENT_PREFIX = 'xcp-persistent-'
@@ -45,10 +46,10 @@ DATABASE_VOLUME_NAME = PERSISTENT_PREFIX + 'database'
 DATABASE_SIZE = 1 << 30  # 1GB.
 DATABASE_PATH = '/var/lib/linstor'
 DATABASE_MKFS = 'mkfs.ext4'
-DATABASE_BACKUP_DIR_MAIN = Path(DATABASE_PATH)
-DATABASE_BACKUP_DIR_SPARE = Path('/var/lib/linstor.d/db-backups')
+DATABASE_BACKUP_LOGDIR = Path('/var/lib/linstor.d/db-backups')
+DATABASE_BACKUP_RELATIVE = Path("../linstor.d/db-backups")
+DATABASE_BACKUP_LOGFILE = DATABASE_BACKUP_LOGDIR / "log.txt"
 DATABASE_BACKUP_NAME_FORMAT = "linstor_database_backup-{}-{}"
-DATABASE_BACKUP_NAME_LATEST = "linstor_database_backup-latest.zip"
 DATABASE_BACKUP_RETENTION = 10
 DATABASE_BACKUP_DATE_FORMAT = "%Y%m%d_%H%M%S"
 LINSTOR_SATELLITE_PORT = 3366
@@ -259,6 +260,8 @@ class LinstorVolumeManagerError(Exception):
     def code(self):
         return self._code
 
+class LinstorDatabaseBackupError(Exception):
+    pass
 
 # ==============================================================================
 
@@ -1788,34 +1791,46 @@ class LinstorVolumeManager(object):
         """
         return self._request_database_path(self._linstor, activate=True)
 
+    def is_controller(self):
+        """Checks if the current host is the Linstor Controller.
+        This is done by checking that the Linstor database path is a mountpoint.
+        Which should only be the case on the Linstor Controller."""
+        return os.path.ismount(DATABASE_PATH)
+
     def database_backup(self, name="", *, delay=0):
         now = datetime.now()
-        # Throttling to avoid too many backups of the same kind on a short period
+        # Throttling to avoid too many backups on a short period
         if delay:
-            _, date_latest = self._get_latest_database_backup(name)
-            if date_latest and ((now - date_latest).total_seconds() < delay):
+            latest = datetime.strptime(
+                self._get_latest_logged_database_backup_date(),
+                DATABASE_BACKUP_DATE_FORMAT)
+            if (now - latest).total_seconds() < delay:
                 return  # No backup for now
-
-        # Create new backup with link to latest
-        filename = DATABASE_BACKUP_NAME_FORMAT.format(now.strftime(DATABASE_BACKUP_DATE_FORMAT), name)
+        # Create new backup
+        date = now.strftime(DATABASE_BACKUP_DATE_FORMAT)
+        filename = DATABASE_BACKUP_NAME_FORMAT.format(date, name)
         self._linstor.controller_backupdb(filename)
-        # Copy to secondary backup location
-        with contextlib.suppress(OSError):
-            os.makedirs(DATABASE_BACKUP_DIR_SPARE, mode=0o755, exist_ok=True)
-            shutil.copy2(
-                (DATABASE_BACKUP_DIR_MAIN / filename).with_suffix(".zip"),
-                DATABASE_BACKUP_DIR_SPARE,
-            )
-        for directory in (DATABASE_BACKUP_DIR_MAIN, DATABASE_BACKUP_DIR_SPARE):
-            # Remove and set latest
-            with contextlib.suppress(OSError):
-                (directory / DATABASE_BACKUP_NAME_LATEST).unlink()
-            os.link(str((directory / filename).with_suffix(".zip")),
-                    str((directory / DATABASE_BACKUP_NAME_LATEST)))
-            # Apply retention
-            for old_file, _ in self._get_sorted_database_backup(directory)[DATABASE_BACKUP_RETENTION:]:
-                os.unlink(old_file)
-        util.SMlog("[database_backup] Created: {}".format(filename))
+        # Relative path are ok for a secondary backup filename:
+        # https://github.com/LINBIT/linstor-server/blob/3e9306a9d8215606544c64c50ced150625ee4926/controller/src/main/java/com/linbit/linstor/api/rest/v1/Controller.java#L408
+        self._linstor.controller_backupdb(str(DATABASE_BACKUP_RELATIVE / filename))
+        self._log_database_backup(date, name)
+        util.SMlog("[database_backup] Created: {}".format(filename), priority=util.LOG_INFO)
+
+    def database_invalidation(self):
+        for directory in (Path(DATABASE_PATH), DATABASE_BACKUP_LOGDIR):
+            file_ok = 0
+            # Validate file and apply retention
+            for database_backup_file, _ in self._get_sorted_database_backup(directory):
+                try:
+                    self._check_database_backup(database_backup_file)
+                    file_ok += 1
+                    if file_ok < DATABASE_BACKUP_RETENTION:
+                        continue
+                except LinstorDatabaseBackupError as error:
+                    util.SMlog("[database_backup] Check failed: `{}` [{}]".format(
+                        error, database_backup_file), priority=util.LOG_ERR)
+                with contextlib.suppress(OSError):
+                    os.unlink(database_backup_file)
 
     @classmethod
     def get_all_group_names(cls, base_name):
@@ -2694,23 +2709,52 @@ class LinstorVolumeManager(object):
         properties.namespace = self._build_volume_namespace(volume_uuid)
         return properties
 
-    def _list_database_backup(self, database_backup_dir, name="*"):
+    def _log_database_backup(self, date, name):
+        """Log a database backup operation: "date name"
+        We cannot assume the pool-master is the same as the linstor-master,
+        this file is on the pool-master, and serves for the throttling."""
+        os.makedirs(DATABASE_BACKUP_LOGDIR, mode=0o755, exist_ok=True)
+        with open(DATABASE_BACKUP_LOGFILE, "a", encoding="utf8") as f:
+            f.write(f"{date} {name}\n")
+
+    def _get_latest_logged_database_backup_date(self):
+        # get last log line if it exists, and return the corresponding date
+        try:
+            with open(DATABASE_BACKUP_LOGFILE, "rb") as f:
+                # seek from the end, with 256 as a most-probable maximum line length
+                f.seek(-min(os.stat(DATABASE_BACKUP_LOGFILE).st_size, 256), os.SEEK_END)
+                return f.read().decode().splitlines()[-1].split()[0]
+        except FileNotFoundError:
+            return "20000101_000000"
+
+    def _list_database_backup(self, database_backup_dir):
         for path in database_backup_dir.glob(DATABASE_BACKUP_NAME_FORMAT.format(
-                "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]", name) + ".zip"):
+                "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]", "*") + ".zip"):
             try:
                 yield path, datetime.strptime(path.name.split("-")[1], DATABASE_BACKUP_DATE_FORMAT)
             except (ValueError, IndexError):
                 continue
 
-    def _get_sorted_database_backup(self, database_backup_dir, name="*"):
-        return sorted(self._list_database_backup(database_backup_dir, name),
+    def _get_sorted_database_backup(self, database_backup_dir):
+        return sorted(self._list_database_backup(database_backup_dir),
                       reverse=True,
-                      key=lambda p: p[0].stat().st_mtime)
+                      key=lambda p: p[1])
 
-    def _get_latest_database_backup(self, name="*"):
-        return max(self._list_database_backup(DATABASE_BACKUP_DIR_MAIN, name),
-                   default=(None, None),
-                   key=lambda p: p[0].stat().st_mtime)
+    def _check_database_backup(self, database_backup_file):
+        try:
+            with zipfile.ZipFile(database_backup_file, mode="r") as archive:
+                if archive.testzip() is not None:
+                    raise LinstorDatabaseBackupError("zip archive CRC failed")
+                linstordb = [f for f in archive.filelist if f.filename == "linstordb.mv.db"]
+                if not linstordb:
+                    raise LinstorDatabaseBackupError("cannot find linstordb.mv.db")
+                linstordb = linstordb[0]
+                if linstordb.file_size == 0:
+                    raise LinstorDatabaseBackupError("linstordb.mv.db is empty")
+        except LinstorDatabaseBackupError:
+            raise
+        except Exception as e:
+            raise LinstorDatabaseBackupError(e) from e
 
     @classmethod
     def _build_sr_namespace(cls):

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1795,7 +1795,7 @@ class LinstorVolumeManager(object):
         return cls._is_mounted(DATABASE_PATH)
 
     @classmethod
-    def database_backup_age(cls):
+    def get_database_backup_age(cls):
         """
         Return the latest backup age in seconds.
         If not called on the Controller, since backups are not available,
@@ -1823,17 +1823,17 @@ class LinstorVolumeManager(object):
         for directory in (DATABASE_BACKUP_DIR_MAIN, DATABASE_BACKUP_DIR_SPARE):
             valid_backup_count = 0
             # Validate file and apply retention
-            for database_backup_file, _ in cls._get_sorted_database_backup(directory):
+            for database_backup_path, _ in cls._get_sorted_database_backup(directory):
                 try:
-                    cls._check_database_backup(database_backup_file)
+                    cls._check_database_backup(database_backup_path)
                     valid_backup_count += 1
                     if valid_backup_count < DATABASE_BACKUP_RETENTION:
                         continue
                 except LinstorDatabaseBackupError as error:
-                    util.SMlog(f"[database_backup] Check failed `{error}` [{database_backup_file}]",
+                    util.SMlog(f"[database_backup] Check failed `{error}` [{database_backup_path}]",
                                priority=util.LOG_ERR)
                 with contextlib.suppress(OSError):
-                    os.unlink(database_backup_file)
+                    os.unlink(database_backup_path)
 
     @classmethod
     def get_all_group_names(cls, base_name):
@@ -2713,7 +2713,7 @@ class LinstorVolumeManager(object):
         return properties
 
     @classmethod
-    def _list_database_backup(cls, database_backup_dir):
+    def _list_database_backups(cls, database_backup_dir):
         """
         List all visible backup files in database_backup_dir.
         DATABASE_BACKUP_DIR_MAIN is only available on the Linstor Controller.
@@ -2733,7 +2733,7 @@ class LinstorVolumeManager(object):
         Return list of backups in database_backup_dir, alongside their creation date.
         Sorted by date from the more recent to the older one.
         """
-        return sorted(cls._list_database_backup(database_backup_dir),
+        return sorted(cls._list_database_backups(database_backup_dir),
                       reverse=True,
                       key=lambda p: p[1])
 
@@ -2743,14 +2743,14 @@ class LinstorVolumeManager(object):
         Return the latest backup in DATABASE_BACKUP_DIR_MAIN, and its creation date.
         Returns (None, timestamp(0)) when none are found.
         None will be found if it is not called on the Linstor Controller.
-        (cf _list_database_backup)
+        (cf _list_database_backups)
         """
-        return max(cls._list_database_backup(DATABASE_BACKUP_DIR_MAIN),
+        return max(cls._list_database_backups(DATABASE_BACKUP_DIR_MAIN),
                    default=(None, datetime.fromtimestamp(0)),
                    key=lambda p: p[1])
 
     @classmethod
-    def _check_database_backup(cls, database_backup_file):
+    def _check_database_backup(cls, database_backup_path):
         """
         Make some validation of a database backup zip-file.
         Check its a valid zipfile, and CRC-test its content.
@@ -2758,13 +2758,16 @@ class LinstorVolumeManager(object):
         Always raises a LinstorDatabaseBackupError if checks failed.
         """
         try:
-            with zipfile.ZipFile(database_backup_file, mode="r") as archive:
+            with zipfile.ZipFile(database_backup_path, mode="r") as archive:
                 if archive.testzip() is not None:
                     raise LinstorDatabaseBackupError("zip archive CRC failed")
-                linstordb = [f for f in archive.filelist if f.filename == "linstordb.mv.db"]
+                linstordb = next((
+                    f
+                    for f in archive.filelist
+                    if f.filename == "linstordb.mv.db"
+                ), None)
                 if not linstordb:
                     raise LinstorDatabaseBackupError("cannot find linstordb.mv.db")
-                linstordb = linstordb[0]
                 if linstordb.file_size == 0:
                     raise LinstorDatabaseBackupError("linstordb.mv.db is empty")
         except (FileNotFoundError, zipfile.BadZipFile, zipfile.LargeZipFile) as e:

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -3049,7 +3049,7 @@ class LinstorVolumeManager(object):
                 except Exception:
                     pass
 
-            if mount == cls._is_mounted(DATABASE_PATH):
+            if mount == cls.is_controller():
                 force_exec(lambda: cls._move_files(
                     DATABASE_PATH, backup_path
                 ))
@@ -3057,7 +3057,7 @@ class LinstorVolumeManager(object):
                     volume_path, DATABASE_PATH, not mount
                 ))
 
-            if mount != cls._is_mounted(DATABASE_PATH):
+            if mount != cls.is_controller():
                 force_exec(lambda: cls._move_files(
                     backup_path, DATABASE_PATH
                 ))

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1801,7 +1801,7 @@ class LinstorVolumeManager(object):
         If not called on the Controller, since backups are not available,
         returns a huge value (a timestamp of now).
         """
-        return (datetime.now() - cls._get_latest_database_backup()).total_seconds()
+        return (datetime.now() - cls._get_latest_database_backup()[1]).total_seconds()
 
     def database_backup(self, name=""):
         # Create new backup
@@ -2714,8 +2714,14 @@ class LinstorVolumeManager(object):
 
     @classmethod
     def _list_database_backup(cls, database_backup_dir):
+        """
+        List all visible backup files in database_backup_dir.
+        DATABASE_BACKUP_DIR_MAIN is only available on the Linstor Controller.
+        DATABASE_BACKUP_DIR_SPARE will list backups previously made when the Host was the Linstor Controller.
+        This may not be useful information if it is not the Controller anymore.
+        """
         for path in database_backup_dir.glob(DATABASE_BACKUP_NAME_FORMAT.format(
-                "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]", "*") + ".zip"):
+                "[0-9]" * 8 + "_" + "[0-9]" * 6, "*") + ".zip"):
             try:
                 yield path, datetime.strptime(path.name.split("-")[1], DATABASE_BACKUP_DATE_FORMAT)
             except (ValueError, IndexError):
@@ -2723,18 +2729,34 @@ class LinstorVolumeManager(object):
 
     @classmethod
     def _get_sorted_database_backup(cls, database_backup_dir):
+        """
+        Return list of backups in database_backup_dir, alongside their creation date.
+        Sorted by date from the more recent to the older one.
+        """
         return sorted(cls._list_database_backup(database_backup_dir),
                       reverse=True,
                       key=lambda p: p[1])
 
     @classmethod
     def _get_latest_database_backup(cls):
+        """
+        Return the latest backup in DATABASE_BACKUP_DIR_MAIN, and its creation date.
+        Returns (None, timestamp(0)) when none are found.
+        None will be found if it is not called on the Linstor Controller.
+        (cf _list_database_backup)
+        """
         return max(cls._list_database_backup(DATABASE_BACKUP_DIR_MAIN),
                    default=(None, datetime.fromtimestamp(0)),
                    key=lambda p: p[1])
 
     @classmethod
     def _check_database_backup(cls, database_backup_file):
+        """
+        Make some validation of a database backup zip-file.
+        Check its a valid zipfile, and CRC-test its content.
+        Check it contains a non-empty linstordb.mv.db file.
+        Always raises a LinstorDatabaseBackupError if checks failed.
+        """
         try:
             with zipfile.ZipFile(database_backup_file, mode="r") as archive:
                 if archive.testzip() is not None:
@@ -2745,8 +2767,6 @@ class LinstorVolumeManager(object):
                 linstordb = linstordb[0]
                 if linstordb.file_size == 0:
                     raise LinstorDatabaseBackupError("linstordb.mv.db is empty")
-        except LinstorDatabaseBackupError:
-            raise
         except (FileNotFoundError, zipfile.BadZipFile, zipfile.LargeZipFile) as e:
             raise LinstorDatabaseBackupError(e) from e
 

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1814,7 +1814,7 @@ class LinstorVolumeManager(object):
         util.SMlog(f"[database_backup] Created: {filename}", priority=util.LOG_INFO)
 
     @classmethod
-    def database_invalidation(cls):
+    def database_backup_validate_and_prune(cls):
         """
         Removes old backup based on two criterias:
         - Validity of the zipfile done by self._check_database_backup.

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -46,9 +46,8 @@ DATABASE_VOLUME_NAME = PERSISTENT_PREFIX + 'database'
 DATABASE_SIZE = 1 << 30  # 1GB.
 DATABASE_PATH = '/var/lib/linstor'
 DATABASE_MKFS = 'mkfs.ext4'
-DATABASE_BACKUP_LOGDIR = Path('/var/lib/linstor.d/db-backups')
-DATABASE_BACKUP_RELATIVE = Path("../linstor.d/db-backups")
-DATABASE_BACKUP_LOGFILE = DATABASE_BACKUP_LOGDIR / "log.txt"
+DATABASE_BACKUP_DIR_MAIN = Path(DATABASE_PATH)
+DATABASE_BACKUP_DIR_SPARE = Path("/var/lib/linstor.d/db-backups")
 DATABASE_BACKUP_NAME_FORMAT = "linstor_database_backup-{}-{}"
 DATABASE_BACKUP_RETENTION = 10
 DATABASE_BACKUP_DATE_FORMAT = "%Y%m%d_%H%M%S"
@@ -1791,44 +1790,48 @@ class LinstorVolumeManager(object):
         """
         return self._request_database_path(self._linstor, activate=True)
 
-    def is_controller(self):
-        """Checks if the current host is the Linstor Controller.
-        This is done by checking that the Linstor database path is a mountpoint.
-        Which should only be the case on the Linstor Controller."""
-        return os.path.ismount(DATABASE_PATH)
+    @classmethod
+    def is_controller(cls):
+        return cls._is_mounted(DATABASE_PATH)
 
-    def database_backup(self, name="", *, delay=0):
-        now = datetime.now()
-        # Throttling to avoid too many backups on a short period
-        if delay:
-            latest = datetime.strptime(
-                self._get_latest_logged_database_backup_date(),
-                DATABASE_BACKUP_DATE_FORMAT)
-            if (now - latest).total_seconds() < delay:
-                return  # No backup for now
+    @classmethod
+    def database_backup_age(cls):
+        """
+        Return the latest backup age in seconds.
+        If not called on the Controller, since backups are not available,
+        returns a huge value (a timestamp of now).
+        """
+        return (datetime.now() - cls._get_latest_database_backup()).total_seconds()
+
+    def database_backup(self, name=""):
         # Create new backup
-        date = now.strftime(DATABASE_BACKUP_DATE_FORMAT)
+        date = datetime.now().strftime(DATABASE_BACKUP_DATE_FORMAT)
         filename = DATABASE_BACKUP_NAME_FORMAT.format(date, name)
         self._linstor.controller_backupdb(filename)
         # Relative path are ok for a secondary backup filename:
         # https://github.com/LINBIT/linstor-server/blob/3e9306a9d8215606544c64c50ced150625ee4926/controller/src/main/java/com/linbit/linstor/api/rest/v1/Controller.java#L408
-        self._linstor.controller_backupdb(str(DATABASE_BACKUP_RELATIVE / filename))
-        self._log_database_backup(date, name)
-        util.SMlog("[database_backup] Created: {}".format(filename), priority=util.LOG_INFO)
+        self._linstor.controller_backupdb(f"../linstor.d/db-backups/{filename}")
+        util.SMlog(f"[database_backup] Created: {filename}", priority=util.LOG_INFO)
 
-    def database_invalidation(self):
-        for directory in (Path(DATABASE_PATH), DATABASE_BACKUP_LOGDIR):
-            file_ok = 0
+    @classmethod
+    def database_invalidation(cls):
+        """
+        Removes old backup based on two criterias:
+        - Validity of the zipfile done by self._check_database_backup.
+        - Number of valid files found, only the nth latest are kept.
+        """
+        for directory in (DATABASE_BACKUP_DIR_MAIN, DATABASE_BACKUP_DIR_SPARE):
+            valid_backup_count = 0
             # Validate file and apply retention
-            for database_backup_file, _ in self._get_sorted_database_backup(directory):
+            for database_backup_file, _ in cls._get_sorted_database_backup(directory):
                 try:
-                    self._check_database_backup(database_backup_file)
-                    file_ok += 1
-                    if file_ok < DATABASE_BACKUP_RETENTION:
+                    cls._check_database_backup(database_backup_file)
+                    valid_backup_count += 1
+                    if valid_backup_count < DATABASE_BACKUP_RETENTION:
                         continue
                 except LinstorDatabaseBackupError as error:
-                    util.SMlog("[database_backup] Check failed: `{}` [{}]".format(
-                        error, database_backup_file), priority=util.LOG_ERR)
+                    util.SMlog(f"[database_backup] Check failed `{error}` [{database_backup_file}]",
+                               priority=util.LOG_ERR)
                 with contextlib.suppress(OSError):
                     os.unlink(database_backup_file)
 
@@ -2709,25 +2712,8 @@ class LinstorVolumeManager(object):
         properties.namespace = self._build_volume_namespace(volume_uuid)
         return properties
 
-    def _log_database_backup(self, date, name):
-        """Log a database backup operation: "date name"
-        We cannot assume the Pool Master is the same as the Linstor Controller,
-        this file is on the Pool Master, and serves for the throttling."""
-        os.makedirs(DATABASE_BACKUP_LOGDIR, mode=0o755, exist_ok=True)
-        with open(DATABASE_BACKUP_LOGFILE, "a", encoding="utf8") as f:
-            f.write(f"{date} {name[:15]}\n")
-
-    def _get_latest_logged_database_backup_date(self):
-        # get last log line if it exists, and return the corresponding date
-        try:
-            with open(DATABASE_BACKUP_LOGFILE, "rb") as f:
-                # seek from the end, a line length can't be more than 32
-                f.seek(-min(os.stat(DATABASE_BACKUP_LOGFILE).st_size, 32), os.SEEK_END)
-                return f.read().decode().splitlines()[-1].split()[0]
-        except FileNotFoundError:
-            return "20000101_000000"
-
-    def _list_database_backup(self, database_backup_dir):
+    @classmethod
+    def _list_database_backup(cls, database_backup_dir):
         for path in database_backup_dir.glob(DATABASE_BACKUP_NAME_FORMAT.format(
                 "20[0-9][0-9][01][0-9][0-3][0-9]_[0-2][0-9][0-5][0-9][0-5][0-9]", "*") + ".zip"):
             try:
@@ -2735,12 +2721,20 @@ class LinstorVolumeManager(object):
             except (ValueError, IndexError):
                 continue
 
-    def _get_sorted_database_backup(self, database_backup_dir):
-        return sorted(self._list_database_backup(database_backup_dir),
+    @classmethod
+    def _get_sorted_database_backup(cls, database_backup_dir):
+        return sorted(cls._list_database_backup(database_backup_dir),
                       reverse=True,
                       key=lambda p: p[1])
 
-    def _check_database_backup(self, database_backup_file):
+    @classmethod
+    def _get_latest_database_backup(cls):
+        return max(cls._list_database_backup(DATABASE_BACKUP_DIR_MAIN),
+                   default=(None, datetime.fromtimestamp(0)),
+                   key=lambda p: p[1])
+
+    @classmethod
+    def _check_database_backup(cls, database_backup_file):
         try:
             with zipfile.ZipFile(database_backup_file, mode="r") as archive:
                 if archive.testzip() is not None:
@@ -2753,7 +2747,7 @@ class LinstorVolumeManager(object):
                     raise LinstorDatabaseBackupError("linstordb.mv.db is empty")
         except LinstorDatabaseBackupError:
             raise
-        except Exception as e:
+        except (FileNotFoundError, zipfile.BadZipFile, zipfile.LargeZipFile) as e:
             raise LinstorDatabaseBackupError(e) from e
 
     @classmethod

--- a/sm_typing/__init__.py
+++ b/sm_typing/__init__.py
@@ -19,3 +19,6 @@ if not hasattr(typing, 'Never'):
 
 if not hasattr(typing, 'Final'):
     Final = None # type: ignore
+
+if not hasattr(typing, "Literal"):
+    from typing_extensions import Literal  # noqa: F401, UP035


### PR DESCRIPTION
* Added secondary backup location outside of Linstor's DRBD mounts.
* Throttling is restricted to backup on the `Linstor Controller` (needs access to files).
* `check_sr` operates a regular backup only if it runs on the `Linstor Controller`, to allow throttling.
* Retention is enforced by `check_sr` on `Controller`, with access to actual files.
* Retention checks all `backup.zip` files for consistency :
  Valid zip with a non-empty `linstordb.mv.db` file inside,
  Reporting errors, and keeping only valid files.