### PR TITLE
feat(linstor): use client when possible to construct journaler

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -1310,7 +1310,9 @@ class LinstorSR(SR.SR):
     def _get_journaler(self):
         if not self._journaler:
             self._journaler = LinstorJournaler(
-                self._linstor.uri, self._group_name, logger=util.SMlog
+                self._group_name,
+                native_client=self._linstor.native_client,
+                logger=util.SMlog
             )
         return self._journaler
 

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -3627,6 +3627,7 @@ class LinstorSR(SR):
                 assert self.sr, "Cannot use `LinstorProxy` without valid `LinstorVolumeManager` instance"
                 return getattr(self.sr._linstor, attr)
 
+        self._linstor = None
         self._linstor_proxy = LinstorProxy(self)
         self._reloadLinstor(journaler_only=True)
 
@@ -3676,17 +3677,19 @@ class LinstorSR(SR):
         group_name = dconf['group-name']
 
         controller_uri = get_controller_uri()
+
+        if not journaler_only:
+            self._linstor = LinstorVolumeManager(
+                controller_uri,
+                group_name,
+                repair=True,
+                logger=util.SMlog
+            )
+
         self.journaler = LinstorJournaler(
-            controller_uri, group_name, logger=util.SMlog
-        )
-
-        if journaler_only:
-            return
-
-        self._linstor = LinstorVolumeManager(
-            controller_uri,
             group_name,
-            repair=True,
+            uri=None if self._linstor else controller_uri,
+            native_client=self._linstor.native_client if self._linstor else None,
             logger=util.SMlog
         )
 

--- a/drivers/linstor-manager
+++ b/drivers/linstor-manager
@@ -352,12 +352,14 @@ def attach(session, args):
         group_name = args['groupName']
 
         controller_uri = get_controller_uri()
-        journaler = LinstorJournaler(
-            controller_uri, group_name, logger=util.SMlog
-        )
         linstor = LinstorVolumeManager(
             controller_uri,
             group_name,
+            logger=util.SMlog
+        )
+        journaler = LinstorJournaler(
+            group_name,
+            native_client=linstor.native_client,
             logger=util.SMlog
         )
         LinstorSR.attach_thin(session, journaler, linstor, sr_uuid, vdi_uuid)

--- a/drivers/linstorjournaler.py
+++ b/drivers/linstorjournaler.py
@@ -50,13 +50,19 @@ class LinstorJournaler:
     def default_logger(*args):
         print(args)
 
-    def __init__(self, uri, group_name, logger=default_logger.__func__):
+    def __init__(
+        self,
+        group_name,
+        uri=None,
+        native_client=None,
+        logger=default_logger.__func__
+    ):
         self._namespace = '{}journal/'.format(
             LinstorVolumeManager._build_sr_namespace()
         )
         self._logger = logger
         self._journal = self._create_journal_instance(
-            uri, group_name, self._namespace
+            group_name, self._namespace, uri=uri, native_client=native_client
         )
 
     def create(self, type, identifier, value):
@@ -144,7 +150,19 @@ class LinstorJournaler:
         self._journal.namespace = self._namespace
 
     @classmethod
-    def _create_journal_instance(cls, uri, group_name, namespace):
+    def _create_journal_instance(cls, group_name, namespace, *, uri=None, native_client=None):
+        if not uri and not native_client:
+            raise LinstorVolumeManagerError(
+                'Either a URI to the LINSTOR controller or a LINSTOR client must be provided'
+            )
+
+        if native_client:
+            return linstor.KV(
+                LinstorVolumeManager._build_group_name(group_name),
+                existing_client=native_client,
+                namespace=namespace
+            )
+
         def connect(uri):
             if not uri:
                 uri = get_controller_uri()

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -414,6 +414,10 @@ class LinstorVolumeManager(object):
         return self._uri
 
     @property
+    def native_client(self) -> linstor.Linstor:
+        return self._linstor
+
+    @property
     def group_name(self):
         """
         Give the used group name.

--- a/mocks/linstor/__init__.py
+++ b/mocks/linstor/__init__.py
@@ -1,0 +1,2 @@
+class Linstor(object):
+    pass


### PR DESCRIPTION
This adds an argument to the constructor of `LinstorJournaler` so it can be constructed with a pre-configured LINSTOR client instead of letting `LinstorJournaler` construct its own client with the given URI. Either a URI or a client needs to be passed to the constructor. If both are passed, the client takes precedence.

A `native_client` property has been added to the `LinstorVolumeManager` class so its LINSTOR client can be used outside of this class.

The instantiation sites of the `LinstorJournaler` class were updated to use `LinstorVolumeManager`'s client where available.