### PR TITLE
qcow2_helper: add support for compressed images

### DIFF
--- a/qcow2/Makefile
+++ b/qcow2/Makefile
@@ -3,15 +3,16 @@ DESTDIR ?=
 DEBUGDIR ?= /opt/xensource/debug
 
 
-OPTS := -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -fopenmp -Ofast
+OPTS  = -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -fopenmp -Ofast
+OPTS += -Wall -Wextra
 
-SRC := qcow2_helper.c lvm-util.c
+SRC = qcow2_helper.c lvm-util.c
 
-BIN := qcow2_helper
+BIN = qcow2_helper
 
 all: qcow2_helper
 
-qcow2_helper: qcow2_helper.c
+qcow2_helper: $(SRC)
 	$(CC) $(OPTS) $(SRC) -o $(BIN)
 
 install: install_qcow2_helper

--- a/qcow2/lvm-util.c
+++ b/qcow2/lvm-util.c
@@ -102,7 +102,7 @@ lvm_parse_pv(struct vg *vg, const char *name, int pvs, uint64_t start)
 	if (i == pvs)
 		return -ENOMEM;
 
-	err = lvm_copy_name(pv->name, name, sizeof(pv->name) - 1);
+	err = lvm_copy_name(pv->name, name, sizeof(pv->name));
 	if (err)
 		return err;
 
@@ -192,10 +192,11 @@ out:
 static int
 lvm_parse_lv_devices(struct vg *vg, struct lv_segment *seg, char *devices)
 {
-	int i;
+	int i, len;
 	uint64_t start, pe_start;
 
-	for (i = 0; i < strlen(devices); i++)
+	len = strlen(devices);
+	for (i = 0; i < len; i++)
 		if (strchr(",()", devices[i]))
 			devices[i] = ' ';
 
@@ -204,14 +205,14 @@ lvm_parse_lv_devices(struct vg *vg, struct lv_segment *seg, char *devices)
 		return -EINVAL;
 	}
 
-	pe_start = -1;
+	pe_start = UINT64_MAX;
 	for (i = 0; i < vg->pv_cnt; i++)
 		if (!strcmp(vg->pvs[i].name, seg->device)) {
 			pe_start = vg->pvs[i].start;
 			break;
 		}
 
-	if (pe_start == -1) {
+	if (pe_start == UINT64_MAX) {
 		EPRINTF("invalid pe_start value, device %s not found?\n",
 			seg->device);
 		EPRINTF("PVs known to VG %s, count %d -\n", vg->name, vg->pv_cnt);
@@ -286,7 +287,7 @@ lvm_scan_lvs(struct vg *vg)
 		lv->segments      = segs;
 		lv->first_segment = seg;
 
-		err = lvm_copy_name(lv->name, name, sizeof(lv->name) - 1);
+		err = lvm_copy_name(lv->name, name, sizeof(lv->name));
 		if (err)
 			goto out;
 		err = -EINVAL;

--- a/qcow2/qcow2_helper.c
+++ b/qcow2/qcow2_helper.c
@@ -1,5 +1,9 @@
+#include <assert.h>
+
 #include "qcow_helper.h"
 #include "lvm-util.h"
+
+static int compressed = 0;
 
 static void transform_header_be_to_le(struct qcow2_header* header){
     SWAP_BE_TO_LE(32, magic);
@@ -98,16 +102,57 @@ uint64_t* get_l2_table(struct qcow2_header* header, int fd, uint64_t offset, uin
     return raw_l2;
 }
 
-int is_l2_allocated(uint64_t l2_entry){
-    if((l2_entry & CLUSTER_TYPE_BIT) != 0){
-        fprintf(stderr, "Cluster is compressed\n");
-        exit(EXIT_FAILURE); //TODO: Read compressed clusters
-    }
-    return ((l2_entry & ALLOCATED_ENTRY_BIT) != 0) || ((l2_entry & STANDARD_CLUSTER_OFFSET_MASK) != 0);
+size_t compressed_bytes(struct qcow2_header* header, uint64_t l2_entry)
+{
+    // Could be computed once, but it's cheap
+    uint64_t csize_shift = CLUSTER_TYPE_BIT - (header->cluster_bits - 8);
+    uint64_t csize_mask  = (1ULL << (header->cluster_bits - 8)) - 1;
+
+    // Ensure that shifting doesn't go beyond bit 55, and mask upper fields,
+    // if header is corrupted or forged
+    assert( ((1ULL << csize_shift) - 1) & ((1ULL << 56) - 1) );
+
+    uint64_t nb_csectors = ((l2_entry >> csize_shift) & csize_mask) + 1;
+    uint64_t coffset     = l2_entry & ((1ULL << csize_shift) - 1);
+
+    // compressed cluster are packed (not aligned), so they can start in middle of
+    // a sector
+    return (nb_csectors * COMPRESSED_SECTOR_SIZE) - (coffset % COMPRESSED_SECTOR_SIZE);
 }
 
-int is_extended_l2_allocated(uint64_t l2_entry_lo, uint64_t l2_entry_hi){
-    if((l2_entry_lo & CLUSTER_TYPE_BIT) != 0){
+size_t l2_allocated_bytes(struct qcow2_header* header, uint64_t l2_entry)
+{
+    // parse compressed (as in qcow2_parse_compressed_l2_entry())
+    if(l2_entry & CLUSTER_TYPE_MASK) {
+        assert((l2_entry & ALLOCATED_ENTRY_MASK) == 0);
+
+        if (compressed)
+            return compressed_bytes(header, l2_entry);
+        else
+            return (1 << header->cluster_bits);
+    }
+    else {
+        // A cluster can be allocated "directly" or could have been snapshoted:
+        // - if allocated != 0, offset != 0
+        // - if snapshoted internally, allocated == 0, offset != 0,
+        // - if snapshoted externally (whole L1/L2 structure is duplicated) :
+        //    - allocated != 0, offset != 0  => cluster is in this image
+        //    - allocated == 0               => backing file must be present
+        // NOTE: we don't use internal snapshot in XCP-ng, but we can't avoid users to
+        //       import images with internal snapshots.
+        int allocated =
+            (l2_entry & ALLOCATED_ENTRY_MASK) || (l2_entry & STANDARD_CLUSTER_OFFSET_MASK);
+
+        if (!allocated)
+            return 0;
+
+        return (1 << header->cluster_bits);
+    }
+}
+
+int is_extended_l2_allocated(uint64_t l2_entry_lo, uint64_t l2_entry_hi)
+{
+    if((l2_entry_lo & CLUSTER_TYPE_MASK) != 0){
         fprintf(stderr, "Cluster is compressed\n");
         exit(EXIT_FAILURE); //TODO: Read compressed clusters
     }
@@ -130,35 +175,31 @@ uint32_t count_set_bits(uint32_t alloc_status_bitmap)
 }
 
 uint32_t get_extended_l2_allocated(uint64_t l2_entry_lo, uint64_t l2_entry_hi){
-    if((l2_entry_lo & CLUSTER_TYPE_BIT) != 0){
+    if((l2_entry_lo & CLUSTER_TYPE_MASK) != 0){
         fprintf(stderr, "Cluster is compressed\n");
         exit(EXIT_FAILURE); //TODO: Read compressed clusters
     }
     return count_set_bits(l2_entry_hi & 0xffffffff);
 }
 
-uint64_t get_allocated_clusters(uint64_t nb_l2_entries, uint64_t *l2_table, int extended_l2)
+uint64_t get_allocated_l2_bytes(struct qcow2_header* header,
+                                uint64_t nb_l2_entries,
+                                uint64_t *l2_table,
+                                int extended_l2)
 {
-    uint64_t allocated_clusters = 0;
+    uint64_t bytes = 0;
     int j;
     for(j = 0; j < nb_l2_entries; j++){
         if (extended_l2) {
-            allocated_clusters += get_extended_l2_allocated(l2_table[j*2], l2_table[j*2+1]);
+            // TODO:
+            bytes += get_extended_l2_allocated(l2_table[j*2], l2_table[j*2+1]);
         } else {
-            if(is_l2_allocated(l2_table[j])){
-                allocated_clusters += 1;
-            }
+            bytes += l2_allocated_bytes(header, l2_table[j]);
         }
     }
-    return allocated_clusters;
+    return bytes;
 }
 
-uint64_t get_cluster_to_byte(uint64_t allocated_clusters, uint64_t cluster_size, int extended_l2){
-    if (extended_l2) {
-        return allocated_clusters * (cluster_size / 32);
-    }
-    return allocated_clusters * cluster_size;
-}
 
 void mark_l1_unallocated(char* bitmap, int i){}
 
@@ -168,7 +209,12 @@ void set_bit(char* m, int bit, int val){
     *m |= (val << bit);
 }
 
-void set_l1_bitmap(char *base_l1_bitmap, uint64_t *l2_table, uint64_t nb_l2_entries, int extended_l2) {
+void set_l1_bitmap(struct qcow2_header* header,
+                   char *base_l1_bitmap,
+                   uint64_t *l2_table,
+                   uint64_t nb_l2_entries,
+                   int extended_l2)
+{
     int j;
     int mementry;
     int bit;
@@ -179,7 +225,7 @@ void set_l1_bitmap(char *base_l1_bitmap, uint64_t *l2_table, uint64_t nb_l2_entr
                 continue;
             }
         } else {
-            if(!is_l2_allocated(l2_table[j])){
+            if(l2_allocated_bytes(header, l2_table[j]) == 0) {
                 continue;
             }
         }
@@ -214,7 +260,7 @@ void dump_bitmap(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64
                 exit(EXIT_FAILURE);
             }
             char* base_l1_bitmap = bitmap + (i * nb_byte_for_l1);
-            set_l1_bitmap(base_l1_bitmap, l2_table, nb_l2_entries, extended_l2);
+            set_l1_bitmap(header, base_l1_bitmap, l2_table, nb_l2_entries, extended_l2);
             free(l2_table);
         }
         else{
@@ -231,11 +277,11 @@ void dump_bitmap(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64
     free(bitmap);
 }
 
-int get_allocated_blocks(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64_t nb_l2_entries, int extended_l2){
-    uint64_t allocated_clusters = 0;
+int get_allocated_bytes(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64_t nb_l2_entries, int extended_l2){
+    uint64_t bytes = 0;
     int i;
 
-    #pragma omp parallel for num_threads(4) reduction (+:allocated_clusters)
+    #pragma omp parallel for num_threads(4) reduction (+:bytes)
     for(i = 0; i < header->l1_size; i++){
         uint64_t *l2_table = NULL;
         uint64_t l1_entry = l1_table[i];
@@ -245,11 +291,11 @@ int get_allocated_blocks(struct qcow2_header* header, int fd, uint64_t *l1_table
                 fprintf(stderr, "Couldn't get L2 Table");
                 exit(EXIT_FAILURE);
             }
-            allocated_clusters += get_allocated_clusters(nb_l2_entries, l2_table, extended_l2);
+            bytes += get_allocated_l2_bytes(header, nb_l2_entries, l2_table, extended_l2);
             free(l2_table);
         }
     }
-    return allocated_clusters;
+    return bytes;
 }
 
 static int qcow2_open(const char *filename, struct qcow2_header *header, int *fd_out) {
@@ -318,7 +364,7 @@ static void cmd_bitmap(int argc, char **argv) {
     close(fd);
 }
 
-static void usage_allocated(void) { fprintf(stderr, "Usage: allocated -f <file>\n"); }
+static void usage_allocated(void) { fprintf(stderr, "Usage: allocated -f <file> -c\n"); }
 
 static void cmd_allocated(int argc, char **argv) {
     char *filename = NULL;
@@ -326,9 +372,10 @@ static void cmd_allocated(int argc, char **argv) {
     struct qcow2_header header;
     uint64_t *l1_table;
 
-    while ((opt = getopt(argc, argv, "f:")) != -1) {
+    while ((opt = getopt(argc, argv, "f:c")) != -1) {
         switch (opt) {
         case 'f': filename = optarg; break;
+        case 'c': compressed = 1; break;
         default:
             usage_allocated();
             exit(EXIT_FAILURE);
@@ -351,8 +398,7 @@ static void cmd_allocated(int argc, char **argv) {
     }
     uint64_t cluster_size = qcow2_cluster_size(&header);
     int extended_l2 = qcow2_extended_l2(&header);
-    uint64_t clusters = get_allocated_blocks(&header, fd, l1_table, qcow2_nb_l2_entries(cluster_size, extended_l2), extended_l2);
-    uint64_t bytes = get_cluster_to_byte(clusters, cluster_size, extended_l2);
+    uint64_t bytes = get_allocated_bytes(&header, fd, l1_table, qcow2_nb_l2_entries(cluster_size, extended_l2), extended_l2);
     printf("%lu\n", bytes);
     free(l1_table);
     close(fd);

--- a/qcow2/qcow2_helper.c
+++ b/qcow2/qcow2_helper.c
@@ -161,27 +161,18 @@ int is_extended_l2_allocated(uint64_t l2_entry_lo, uint64_t l2_entry_hi)
     return l2_entry_hi & 0xffffffff;
 }
 
-uint32_t count_set_bits(uint32_t alloc_status_bitmap)
+uint32_t count_set_bits(uint32_t bitmap)
 {
-    uint32_t count = 0;
-
-    if (alloc_status_bitmap == 0)
-        return 0;
-
-    while (alloc_status_bitmap) {
-        alloc_status_bitmap &= alloc_status_bitmap - 1;
-        count++;
-    }
-
-    return count;
+    return __builtin_popcount(bitmap);
 }
 
-uint32_t get_extended_l2_allocated(uint64_t l2_entry_lo, uint64_t l2_entry_hi){
-    if((l2_entry_lo & CLUSTER_TYPE_MASK) != 0){
+uint32_t extended_l2_allocated_bytes(struct qcow2_header* header, uint64_t l2_entry_lo, uint64_t l2_entry_hi)
+{
+    if(l2_entry_lo & CLUSTER_TYPE_MASK) {
         fprintf(stderr, "Cluster is compressed\n");
         exit(EXIT_FAILURE); //TODO: Read compressed clusters
     }
-    return count_set_bits(l2_entry_hi & 0xffffffff);
+    return __builtin_popcount(l2_entry_hi & 0xffffffff) * (1 << header->cluster_bits) / 32;
 }
 
 uint64_t get_allocated_l2_bytes(struct qcow2_header* header,
@@ -194,8 +185,7 @@ uint64_t get_allocated_l2_bytes(struct qcow2_header* header,
 
     for(j = 0; j < nb_l2_entries; j++){
         if (extended_l2) {
-            // TODO:
-            bytes += get_extended_l2_allocated(l2_table[j*2], l2_table[j*2+1]);
+            bytes += extended_l2_allocated_bytes(header, l2_table[j*2], l2_table[j*2+1]);
         } else {
             bytes += l2_allocated_bytes(header, l2_table[j]);
         }

--- a/qcow2/qcow2_helper.c
+++ b/qcow2/qcow2_helper.c
@@ -152,11 +152,10 @@ size_t l2_allocated_bytes(struct qcow2_header* header, uint64_t l2_entry)
     }
 }
 
-int is_extended_l2_allocated(uint64_t l2_entry_lo, uint64_t l2_entry_hi)
+int is_extended_l2_allocated(struct qcow2_header* header, uint64_t l2_entry_lo, uint64_t l2_entry_hi)
 {
-    if((l2_entry_lo & CLUSTER_TYPE_MASK) != 0){
-        fprintf(stderr, "Cluster is compressed\n");
-        exit(EXIT_FAILURE); //TODO: Read compressed clusters
+    if(l2_entry_lo & CLUSTER_TYPE_MASK) {
+        return l2_allocated_bytes(header, l2_entry_lo);
     }
     return l2_entry_hi & 0xffffffff;
 }
@@ -168,11 +167,11 @@ uint32_t count_set_bits(uint32_t bitmap)
 
 uint32_t extended_l2_allocated_bytes(struct qcow2_header* header, uint64_t l2_entry_lo, uint64_t l2_entry_hi)
 {
-    if(l2_entry_lo & CLUSTER_TYPE_MASK) {
-        fprintf(stderr, "Cluster is compressed\n");
-        exit(EXIT_FAILURE); //TODO: Read compressed clusters
-    }
-    return __builtin_popcount(l2_entry_hi & 0xffffffff) * (1 << header->cluster_bits) / 32;
+    // if compression enable, bitmap is ignored (see qcow2_get_subcluster_type())
+    if (l2_entry_lo & CLUSTER_TYPE_MASK)
+        return l2_allocated_bytes(header, l2_entry_lo);
+    else
+        return count_set_bits(l2_entry_hi & 0xffffffff) * (1 << header->cluster_bits) / 32;
 }
 
 uint64_t get_allocated_l2_bytes(struct qcow2_header* header,
@@ -210,7 +209,7 @@ void set_l1_bitmap(struct qcow2_header* header,
 
     for (j = 0; j < nb_l2_entries; j++) {
         if (extended_l2) {
-            if(!is_extended_l2_allocated(l2_table[j*2], l2_table[j*2+1])) {
+            if(!is_extended_l2_allocated(header, l2_table[j*2], l2_table[j*2+1])) {
                 continue;
             }
         } else {

--- a/qcow2/qcow2_helper.c
+++ b/qcow2/qcow2_helper.c
@@ -6,25 +6,25 @@
 
 static int compressed = 0;
 
-static void transform_header_be_to_le(struct qcow2_header* header){
-    SWAP_BE_TO_LE(32, magic);
-    SWAP_BE_TO_LE(32, version);
-    SWAP_BE_TO_LE(64, backing_file_offset);
-    SWAP_BE_TO_LE(32, backing_file_size);
-    SWAP_BE_TO_LE(32, cluster_bits);
-    SWAP_BE_TO_LE(64, size);
-    SWAP_BE_TO_LE(32, crypt_method);
-    SWAP_BE_TO_LE(32, l1_size);
-    SWAP_BE_TO_LE(64, l1_table_offset);
-    SWAP_BE_TO_LE(64, refcount_table_offset);
-    SWAP_BE_TO_LE(32, refcount_table_clusters);
-    SWAP_BE_TO_LE(32, nb_snapshots);
-    SWAP_BE_TO_LE(64, snapshots_offset);
-    SWAP_BE_TO_LE(64, incompatible_features);
-    SWAP_BE_TO_LE(64, compatible_features);
-    SWAP_BE_TO_LE(64, autoclear_features);
-    SWAP_BE_TO_LE(32, refcount_order);
-    SWAP_BE_TO_LE(32, header_length);
+static void qcow2_header_to_host_order(struct qcow2_header* header){
+    BE_TO_HOST(32, magic);
+    BE_TO_HOST(32, version);
+    BE_TO_HOST(64, backing_file_offset);
+    BE_TO_HOST(32, backing_file_size);
+    BE_TO_HOST(32, cluster_bits);
+    BE_TO_HOST(64, size);
+    BE_TO_HOST(32, crypt_method);
+    BE_TO_HOST(32, l1_size);
+    BE_TO_HOST(64, l1_table_offset);
+    BE_TO_HOST(64, refcount_table_offset);
+    BE_TO_HOST(32, refcount_table_clusters);
+    BE_TO_HOST(32, nb_snapshots);
+    BE_TO_HOST(64, snapshots_offset);
+    BE_TO_HOST(64, incompatible_features);
+    BE_TO_HOST(64, compatible_features);
+    BE_TO_HOST(64, autoclear_features);
+    BE_TO_HOST(32, refcount_order);
+    BE_TO_HOST(32, header_length);
 }
 
 char* qcow2_get_backing_file(struct qcow2_header* header, int fd, uint64_t device_offset){
@@ -71,7 +71,7 @@ uint64_t* get_l1_offset(struct qcow2_header* header, int fd){
     }
 
     for(i = 0; i < header->l1_size; i++){
-        raw_l1[i] = (__builtin_bswap64(raw_l1[i]) & L2_OFFSET_MASK);
+        raw_l1[i] = (be64toh(raw_l1[i]) & L2_OFFSET_MASK);
     }
 
     return raw_l1;
@@ -98,7 +98,7 @@ uint64_t* get_l2_table(struct qcow2_header* header, int fd, uint64_t offset, uin
     }
 
     for(i = 0; i < nb_l2_entries * (extended_l2 ? 2 : 1); i++){
-        raw_l2[i] = __builtin_bswap64(raw_l2[i]);
+        raw_l2[i] = be64toh(raw_l2[i]);
     }
 
     return raw_l2;
@@ -302,7 +302,7 @@ static int qcow2_open(const char *filename, struct qcow2_header *header, int *fd
         close(fd);
         return -1;
     }
-    transform_header_be_to_le(header);
+    qcow2_header_to_host_order(header);
     if (header->magic != QCOW2_MAGIC) {
         fprintf(stderr, "MAGIC is wrong\n");
         close(fd);
@@ -454,7 +454,7 @@ struct qcow2_header* get_header_from_device(struct lv* lv, int fd){
         fprintf(stderr, "Failed reading file %s\n", lv->name);
         goto err_free_header;
     }
-    transform_header_be_to_le(header);
+    qcow2_header_to_host_order(header);
     if (header->magic != QCOW2_MAGIC) {
         fprintf(stderr, "MAGIC is wrong for %s\n", lv->name);
         goto err_free_header;
@@ -481,14 +481,14 @@ static uint32_t read_data_from_qcow2_header(int fd, size_t offset){
     if(pread(fd, &data, 4, offset) < 1){
         exit(EXIT_FAILURE); //TODO: Handle error correctly
     }
-    data = __builtin_bswap32(data);
+    data = be32toh(data);
     return data;
 }
 
 void transform_custom_header_bswap(struct custom_header* custom_header){
-    custom_header->type = __builtin_bswap32(custom_header->type);
-    custom_header->length = __builtin_bswap32(custom_header->length);
-    // custom_header->custom_header_data = __builtin_bswap64(custom_header->custom_header_data);
+    custom_header->type = be32toh(custom_header->type);
+    custom_header->length = be32toh(custom_header->length);
+    // custom_header->custom_header_data = be64toh(custom_header->custom_header_data);
     /**
      The data in the custom header is little endian when it should be big endian in qcow2
      It's because the python code writing the hidden status wrote directly at the offset of the data

--- a/qcow2/qcow2_helper.c
+++ b/qcow2/qcow2_helper.c
@@ -309,6 +309,18 @@ static int qcow2_open(const char *filename, struct qcow2_header *header, int *fd
         return -1;
     }
 
+    // XXX: do we want to support snapshots ?
+    //      currently result would silently undercount space
+    //      As with compression, XCP-ng doesn't support internal snapshots but
+    //      we can't avoid a user to import an image with snapshots
+    if (header->nb_snapshots != 0) {
+        fprintf(stderr,
+                "ERROR: %s: image has %u internal snapshot(s), not supported !\n",
+                filename, header->nb_snapshots);
+        close(fd);
+        return -1;
+    }
+
     *fd_out = fd;
     return 0;
 }

--- a/qcow2/qcow2_helper.c
+++ b/qcow2/qcow2_helper.c
@@ -2,6 +2,7 @@
 
 #include "qcow_helper.h"
 #include "lvm-util.h"
+#include "util.h"
 
 static int compressed = 0;
 
@@ -49,10 +50,11 @@ char* qcow2_get_backing_file(struct qcow2_header* header, int fd, uint64_t devic
 }
 
 uint64_t* get_l1_offset(struct qcow2_header* header, int fd){
-    int i, err = 0;
+    int err = 0;
     uint64_t* raw_l1 = NULL;
     uint64_t l1_offset = header->l1_table_offset;
     uint32_t l1_table_size = sizeof(uint64_t) * header->l1_size;
+    uint32_t i;
 
     raw_l1 = malloc(l1_table_size);
     if(raw_l1 == NULL){
@@ -76,10 +78,10 @@ uint64_t* get_l1_offset(struct qcow2_header* header, int fd){
 }
 
 uint64_t* get_l2_table(struct qcow2_header* header, int fd, uint64_t offset, uint64_t nb_l2_entries, int extended_l2){
-    int i;
     ssize_t bytes_read;
     uint64_t* raw_l2 = NULL;
     uint64_t cluster_size = (1 << header->cluster_bits);
+    size_t i;
 
     raw_l2 = malloc(cluster_size);
     if(raw_l2 == NULL){
@@ -188,7 +190,8 @@ uint64_t get_allocated_l2_bytes(struct qcow2_header* header,
                                 int extended_l2)
 {
     uint64_t bytes = 0;
-    int j;
+    size_t j;
+
     for(j = 0; j < nb_l2_entries; j++){
         if (extended_l2) {
             // TODO:
@@ -201,10 +204,6 @@ uint64_t get_allocated_l2_bytes(struct qcow2_header* header,
 }
 
 
-void mark_l1_unallocated(char* bitmap, int i){}
-
-void mark_l2_unallocated(char* bitmap, int i, int j){}
-
 void set_bit(char* m, int bit, int val){
     *m |= (val << bit);
 }
@@ -215,7 +214,7 @@ void set_l1_bitmap(struct qcow2_header* header,
                    uint64_t nb_l2_entries,
                    int extended_l2)
 {
-    int j;
+    unsigned int j;
     int mementry;
     int bit;
 
@@ -237,7 +236,8 @@ void set_l1_bitmap(struct qcow2_header* header,
 }
 
 void dump_bitmap(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64_t nb_l2_entries, int extended_l2){
-    int i, n;
+    size_t i;
+    int n;
     char* bitmap = NULL;
     uint64_t cluster_size = (1 << header->cluster_bits); //cluster size in bytes
     uint64_t total_blocks, bitmap_size;
@@ -265,7 +265,7 @@ void dump_bitmap(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64
         }
         else{
             //Mark L1 (and subsequent L2) non allocated
-            mark_l1_unallocated(bitmap, i); // The bytes are already zeroed, we don't need to do anything
+            // mark_l1_unallocated(bitmap, i); // The bytes are already zeroed, we don't need to do anything
             // memset(base_l1_bitmap, 0, nb_byte_for_l1); //Mark the whole L1 as being unused
         }
     }
@@ -279,7 +279,7 @@ void dump_bitmap(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64
 
 int get_allocated_bytes(struct qcow2_header* header, int fd, uint64_t *l1_table, uint64_t nb_l2_entries, int extended_l2){
     uint64_t bytes = 0;
-    int i;
+    size_t i;
 
     #pragma omp parallel for num_threads(4) reduction (+:bytes)
     for(i = 0; i < header->l1_size; i++){
@@ -505,8 +505,8 @@ size_t find_custom_header(struct qcow2_header* header, int fd, uint64_t device_o
 
     current_offset = header_length;
     current_offset += device_offset;
-    
-    do{
+
+    do {
         ext_type = read_data_from_qcow2_header(fd, current_offset);
         ext_len = read_data_from_qcow2_header(fd, current_offset+4);
         if(ext_type == CUSTOM_HEADER_TYPE){
@@ -522,7 +522,7 @@ size_t find_custom_header(struct qcow2_header* header, int fd, uint64_t device_o
 static int fill_scan_info_from_lv(struct lv *lv, struct scan_info *info) {
     int fd;
 
-    strncpy(info->name, lv->name, NAME_MAX_SIZE);
+    safe_strncpy(info->name, lv->name, MIN(sizeof(info->name), sizeof(lv->name)));
     info->size = lv->size;
 
     /* Getting header from the underlying device*/
@@ -539,20 +539,24 @@ static int fill_scan_info_from_lv(struct lv *lv, struct scan_info *info) {
     char* backing_file_name = get_backing_file_from_device(header, lv, fd);
     if(backing_file_name){
         char* parent_lv_name = basename(backing_file_name); //Transform the backing name from full path of the LV to just the LV name
-        strncpy(info->parent, parent_lv_name, NAME_MAX_SIZE);
+        safe_strncpy(info->parent, parent_lv_name, sizeof(info->parent));
         // strncpy(info->parent, backing_file_name, strlen(backing_file_name));
         //The existing code in qcow2util.py might need the full path though
         free(backing_file_name);
     }
-    else{
-        strncpy(info->parent, "none", 5);
+    else {
+        safe_strncpy(info->parent, "none", sizeof(info->parent));
     }
 
     /* Getting hidden from custom header */
     size_t custom_header_offset = find_custom_header(header, fd, lv->first_segment.pe_start);
     if(custom_header_offset){
         struct custom_header custom_header;
-        pread(fd, &custom_header, sizeof(struct custom_header), custom_header_offset);
+        int err;
+        err = pread(fd, &custom_header, sizeof(struct custom_header), custom_header_offset);
+        if(err < 0){
+            exit(EXIT_FAILURE); //TODO: Handle error correctly
+        }
         transform_custom_header_bswap(&custom_header);
         info->hidden = custom_header.data;
     }
@@ -678,14 +682,18 @@ static const command_t commands[] = {
 static void usage_help(void) { fprintf(stderr, "Usage: help\n"); }
 
 static void cmd_help(int argc, char **argv) {
-    int i;
+    size_t i;
+
+    (void)argc;
+    (void)argv;
+
     fprintf(stderr, "Usage: qcow2_helper <command> [options]\n\nCommands:\n");
     for (i = 0; i < ARRAY_SIZE(commands); i++)
         commands[i].usage();
 }
 
 int main(int argc, char *argv[]) {
-    int i;
+    size_t i;
 
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <command> [options]\nRun '%s help' for a list of commands.\n", argv[0], argv[0]);

--- a/qcow2/qcow_helper.h
+++ b/qcow2/qcow_helper.h
@@ -10,13 +10,18 @@
 #include <string.h>
 #include <unistd.h>
 
-#define QCOW2_HEADER_SIZE 104
-#define QCOW2_MAGIC 0x514649FB
+#define QCOW2_HEADER_SIZE             104
+#define QCOW2_MAGIC                   0x514649FB
 
-#define L2_OFFSET_MASK 0x00FFFFFFFFFFFF00
-#define STANDARD_CLUSTER_OFFSET_MASK 0x00FFFFFFFFFFFF00 /* Bits 9-55 are offset of standard cluster */
-#define CLUSTER_TYPE_BIT (1UL << 62) /* 0 for standard, 1 for compressed cluster */
-#define ALLOCATED_ENTRY_BIT (1UL << 63) /* Bit 63 is the allocated bit for standard cluster */
+#define L2_OFFSET_MASK                0x00FFFFFFFFFFFF00
+#define STANDARD_CLUSTER_OFFSET_MASK  0x00FFFFFFFFFFFF00 /* Bits 9-55 are offset of standard cluster */
+
+#define COMPRESSED_SECTOR_SIZE     512
+#define COMPRESSED_SECTOR_MASK     (COMPRESSED_SECTOR_SIZE - 1)
+
+#define CLUSTER_TYPE_BIT           62
+#define CLUSTER_TYPE_MASK          (1UL << CLUSTER_TYPE_BIT) /* 0 for standard, 1 for compressed cluster */
+#define ALLOCATED_ENTRY_MASK       (1UL << 63)               /* Bit 63 is the allocated bit for standard cluster */
 
 /* Incompatible features */
 #define INCOMPATIBLE_FEATURE_EXTENDED_L2 0x0010

--- a/qcow2/qcow_helper.h
+++ b/qcow2/qcow_helper.h
@@ -69,8 +69,8 @@ struct qcow2_header {
     uint32_t header_length;
 } __attribute__((packed));
 
-#define SWAP_BE_TO_LE(size, x) \
-    header->x = __builtin_bswap ##size(header->x)
+#define BE_TO_HOST(size, x) \
+    header->x = be ##size## toh(header->x)
 
 static inline uint64_t qcow2_cluster_size(const struct qcow2_header *header) {
     return (uint64_t)1 << header->cluster_bits;

--- a/qcow2/util.h
+++ b/qcow2/util.h
@@ -34,19 +34,23 @@
 #include <stddef.h>
 #include <string.h>
 
-#define ARRAY_SIZE(_a) (sizeof(_a)/sizeof((_a)[0]))
+#ifndef ARRAY_SIZE
+# define ARRAY_SIZE(_a) (sizeof(_a)/sizeof((_a)[0]))
+#endif
+
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
 
 /*
  * Strncpy variant that guarantees to terminate the string
  */
-static inline char *
+static inline void
 safe_strncpy(char *dest, const char *src, size_t n)
 {
-	char *pdest;
-	pdest = strncpy(dest, src, n - 1);
-	if (n > 0)
-		dest[n - 1] = '\0';
-	return pdest;
+	if (n > 0) {
+		size_t len = strnlen(src, n - 1);
+		memcpy(dest, src, len);
+		dest[len] = '\0';
+	}
 }
 
 #endif /* __TAPDISK_UTIL_H__ */


### PR DESCRIPTION
Checked against 4 different images with combinaison of compression an extended_l2.
"allocated" command looks fine (result depend on COMPRESSED macro flag).
"bitmap" gives the same output for each.