### PR TITLE
fix(qcow2): read allocated size only when needed

### DIFF
--- a/drivers/qcow2util.py
+++ b/drivers/qcow2util.py
@@ -486,7 +486,6 @@ class QCowUtil(CowUtil):
         cowinfo.sizeVirt = self.header["virtual_disk_size"]
         cowinfo.sizePhys = self.getSizePhys(path)
         cowinfo.hidden = self.getHidden(path)
-        cowinfo.sizeAllocated = self.getAllocatedSize(path)
         if includeParent:
             parent_path = self.header["parent"]
             if parent_path != "":


### PR DESCRIPTION
Reading the allocated size systematically for FileVDI is costly and is only used by the GC for specific VDIs, this align the reading of the allocated size with the behavior of LVMVDI where it's only obtained when needed.

For a SR of 20k (empty) QCOW2 VDIs, we get the scan to go from:
```
real    3m34.294s
```
to:
```
real    0m21.022s
```
For VDIs with data, this could be even bigger.