### PR TITLE
fix(qcow2): limit raw snapshot size

### DIFF
--- a/drivers/qcow2util.py
+++ b/drivers/qcow2util.py
@@ -841,7 +841,7 @@ class QCowUtil(CowUtil):
 
     @override
     def canSnapshotRaw(self, size: int) -> bool:
-        return True
+        return size <= MAX_QCOW_SIZE
 
     @override
     def check(


### PR DESCRIPTION
The function `canSnapshotRaw` give the size of the raw VDI as parameter, `vhdutil` use this size to compare to VHD max size while `qcow2util` always answered True.
This add the check for max QCOW2 size