### PR TITLE
feat(linstor): handle ENODATA errors with linstor VDIs

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -438,10 +438,15 @@ class TapCtl(object):
             try:
                 cls._pread(args)
             except TapCtl.CommandFailure as e:
+                error_code = e.get_error_code()
+                if error_code == errno.ENODATA:
+                    raise RetryLoop.TransientFailure(e)
+                if error_code not in (errno.EROFS, errno.EMEDIUMTYPE):
+                    raise
                 match = TAP_CTL_ERROR_PATTERN.search(e.info.get("errmsg", ""))
                 if match and match.group("reason"):
                     drbd_path = match.group("reason")
-                if e.get_error_code() in (errno.EROFS, errno.EMEDIUMTYPE) and Tapdisk.abort_linstor_gc(drbd_path):
+                if Tapdisk.abort_linstor_gc(drbd_path):
                     raise RetryLoop.TransientFailure(e)
                 raise
 
@@ -933,7 +938,7 @@ class Tapdisk(object):
                             if err in (errno.EROFS, errno.EMEDIUMTYPE) and cls.abort_linstor_gc(drbd_path):
                                 continue
 
-                            if err in (errno.EIO, errno.EAGAIN, errno.EROFS, errno.EMEDIUMTYPE) and retry_open < 1:
+                            if err in (errno.EIO, errno.EAGAIN, errno.EROFS, errno.EMEDIUMTYPE, errno.ENODATA) and retry_open < 1:
                                 retry_open += 1
                                 time.sleep(1)
                                 continue

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -30,7 +30,6 @@ import copy
 from lock import Lock
 import util
 import xmlrpc.client
-import http.client
 import errno
 import signal
 import subprocess
@@ -1556,6 +1555,13 @@ class VDI(object):
             util.logException("BLKTAP2:call_pluginhandler %s" % e)
             return False
 
+    @util.xapi_safe_call
+    def _call_xapi_plugin(self, *args):
+        """
+        wrapper to retry xenapi.host.call_plugin on XAPI HTTP failure.
+        """
+        return self._session.xenapi.host.call_plugin(*args)
+
     def _add_tag(self, vdi_uuid, writable):
         util.SMlog("Adding tag to: %s" % vdi_uuid)
         attach_mode = "RO"
@@ -1601,6 +1607,7 @@ class VDI(object):
         util.SMlog("Activate lock succeeded")
         return True
 
+    @util.xapi_safe_call
     def _check_tag(self, vdi_uuid):
         vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)
         sm_config = self._session.xenapi.VDI.get_sm_config(vdi_ref)
@@ -1609,6 +1616,7 @@ class VDI(object):
             return False
         return True
 
+    @util.xapi_safe_call
     def _remove_tag(self, vdi_uuid):
         vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)
         host_ref = self._session.xenapi.host.get_by_uuid(util.get_this_host())
@@ -1620,8 +1628,9 @@ class VDI(object):
         else:
             util.SMlog("_remove_tag: host key %s not found, ignore" % host_key)
 
+    @util.xapi_safe_call
     def _get_pool_config(self, pool_name):
-        pool_info = dict()
+        pool_info = {}
         vdi_ref = self.target.vdi.sr.srcmd.params.get('vdi_ref')
         if not vdi_ref:
             # attach_from_config context: HA disks don't need to be in any
@@ -1706,9 +1715,7 @@ class VDI(object):
         options = {"rdonly": not writable}
         options.update(caching_params)
 
-        sr_ref = self.target.vdi.sr.srcmd.params.get('sr_ref')
-        sr_other_config = self._session.xenapi.SR.get_other_config(sr_ref)
-        for i in range(self.ATTACH_DETACH_RETRY_SECS):
+        for _ in range(self.ATTACH_DETACH_RETRY_SECS):
             try:
                 if self._activate_locked(sr_uuid, vdi_uuid, options):
                     return
@@ -1795,8 +1802,8 @@ class VDI(object):
         host_ref = self._get_sr_master_host_ref()
         for vdi in vdi_to_cancel:
             args = {"sr_uuid": sr_uuid, "vdi_uuid": vdi}
-            util.SMlog("Calling cancel_coalesce_master with args: {}".format(args))
-            self._session.xenapi.host.call_plugin(\
+            util.SMlog(f"Calling cancel_coalesce_master with args: {args}")
+            self._call_xapi_plugin(
                 host_ref, PLUGIN_ON_SLAVE, "cancel_coalesce_master", args)
 
         return True
@@ -1871,22 +1878,9 @@ class VDI(object):
             util.SMlog("Exception in activate/attach")
             if self.tap_wanted():
                 util.fistpoint.activate_custom_fn(
-                        "blktap_activate_error_handling",
-                        lambda: time.sleep(30))
-                while True:
-                    try:
-                        self._remove_tag(vdi_uuid)
-                        break
-                    except xmlrpc.client.ProtocolError as e:
-                        # If there's a connection error, keep trying forever.
-                        if e.errcode == http.HTTPStatus.INTERNAL_SERVER_ERROR.value:
-                            continue
-                        else:
-                            util.SMlog('failed to remove tag: %s' % e)
-                            break
-                    except Exception as e:
-                        util.SMlog('failed to remove tag: %s' % e)
-                        break
+                    "blktap_activate_error_handling",
+                    lambda: time.sleep(30))
+                self._remove_tag(vdi_uuid)
             raise
         finally:
             vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)

--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -71,6 +71,10 @@ class ErofsLinstorCallException(LinstorCallException):
 class NoPathLinstorCallException(LinstorCallException):
     pass
 
+
+class NoDataLinstorCallException(LinstorCallException):
+    pass
+
 def log_successful_call(target_host, device_path, vdi_uuid, remote_method, response):
     util.SMlog('Successful access on {} for device {} ({}): `{}` => {}'.format(
         target_host, device_path, vdi_uuid, remote_method, str(response)
@@ -538,6 +542,8 @@ class LinstorCowUtil:
                 except util.CommandException as e:
                     if e.code == errno.EROFS or e.code == errno.EMEDIUMTYPE:
                         raise ErofsLinstorCallException(e)  # Break retry calls.
+                    if e.code == errno.ENODATA:
+                        raise NoDataLinstorCallException(e)
                     if e.code == errno.ENOENT:
                         raise NoPathLinstorCallException(e)
                     raise e

--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -221,7 +221,7 @@ class LinstorCowUtil:
                             if e.errno == errno.ENODATA:
                                 time.sleep(2)
                                 continue
-                            if e.errno == errno.EROFS or e.errno == errno.EMEDIUMTYPE:
+                            if e.errno in (errno.EROFS, errno.EMEDIUMTYPE):
                                 openers = self._linstor.get_volume_openers(vdi_uuid)
                                 util.SMlog(f'Volume not attachable because used. Openers: {openers}')
                                 if cb_openers:
@@ -540,7 +540,7 @@ class LinstorCowUtil:
                 try:
                     return local_method(device_path, *args, **kwargs)
                 except util.CommandException as e:
-                    if e.code == errno.EROFS or e.code == errno.EMEDIUMTYPE:
+                    if e.code in (errno.EROFS, errno.EMEDIUMTYPE):
                         raise ErofsLinstorCallException(e)  # Break retry calls.
                     if e.code == errno.ENODATA:
                         raise NoDataLinstorCallException(e)

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -39,6 +39,7 @@ import stat
 import xs_errors
 import XenAPI # pylint: disable=import-error
 import xmlrpc.client
+import http.client
 import base64
 import syslog
 import resource
@@ -781,6 +782,28 @@ def get_localAPI_session():
     except:
         raise xs_errors.XenError('APISession')
     return session
+
+
+def xapi_safe_call(function):
+    """
+    Decorator to catch classic XAPI connection problems and retry forever.
+    The method should be only called for XAPI calls.
+    eg: blktap2.py#VDI:_remove_tag()
+    """
+    def wrapper(*args, **kwargs):
+        call_str = f"{function.__name__}(args={args}, kwargs={kwargs})"
+        while True:
+            try:
+                return function(*args, **kwargs)
+            except xmlrpc.client.ProtocolError as e:
+                # If there's a connection error, keep trying forever.
+                if e.errcode == http.HTTPStatus.INTERNAL_SERVER_ERROR.value:
+                    continue
+                raise
+            except Exception as e:
+                SMlog(f"Failed XAPI call `{call_str}`: `{e}`")
+                raise
+    return wrapper
 
 
 def get_this_host():


### PR DESCRIPTION
- Do not retry locally in linstorhostcall if ENODATA
- Handle ENODATA as a retriable error in blktap2.py
- Rewrite error code checks for improved readability

ENODATA in the context of DRBD means that the current volume is
either diskless or deemed Inconsistent but has no connection to
another UpToDate volume. In the case of linstorcowutil calls,
try on another host. In the case of blktap calls, handle the error
as a retriable error to cover cases where the ENODATA is only
a short, transient issue.