### PR TITLE
fix(blktap2): Retry tag removal on XAPI HTTP failure.

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1555,6 +1555,13 @@ class VDI(object):
             util.logException("BLKTAP2:call_pluginhandler %s" % e)
             return False
 
+    @util.xapi_safe_call
+    def _call_xapi_plugin(self, *args):
+        """
+        wrapper to retry xenapi.host.call_plugin on XAPI HTTP failure.
+        """
+        return self._session.xenapi.host.call_plugin(*args)
+
     def _add_tag(self, vdi_uuid, writable):
         util.SMlog("Adding tag to: %s" % vdi_uuid)
         attach_mode = "RO"
@@ -1797,8 +1804,8 @@ class VDI(object):
         host_ref = self._get_sr_master_host_ref()
         for vdi in vdi_to_cancel:
             args = {"sr_uuid": sr_uuid, "vdi_uuid": vdi}
-            util.SMlog("Calling cancel_coalesce_master with args: {}".format(args))
-            self._session.xenapi.host.call_plugin(\
+            util.SMlog(f"Calling cancel_coalesce_master with args: {args}")
+            self._call_xapi_plugin(
                 host_ref, PLUGIN_ON_SLAVE, "cancel_coalesce_master", args)
 
         return True

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -30,7 +30,6 @@ import copy
 from lock import Lock
 import util
 import xmlrpc.client
-import http.client
 import errno
 import signal
 import subprocess
@@ -1609,7 +1608,7 @@ class VDI(object):
             return False
         return True
 
-    @util.call_XAPI_until_httpOK
+    @util.xapi_safe_call
     def _remove_tag(self, vdi_uuid):
         vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)
         host_ref = self._session.xenapi.host.get_by_uuid(util.get_this_host())
@@ -1621,8 +1620,9 @@ class VDI(object):
         else:
             util.SMlog("_remove_tag: host key %s not found, ignore" % host_key)
 
+    @util.xapi_safe_call
     def _get_pool_config(self, pool_name):
-        pool_info = dict()
+        pool_info = {}
         vdi_ref = self.target.vdi.sr.srcmd.params.get('vdi_ref')
         if not vdi_ref:
             # attach_from_config context: HA disks don't need to be in any
@@ -1940,6 +1940,7 @@ class VDI(object):
             self._detach(sr_uuid, vdi_uuid)
         if self.tap_wanted():
             self._remove_tag(vdi_uuid)
+
         return True
 
     def _resetPhylink(self, sr_uuid, vdi_uuid, path):

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1600,6 +1600,7 @@ class VDI(object):
         util.SMlog("Activate lock succeeded")
         return True
 
+    @util.xapi_safe_call
     def _check_tag(self, vdi_uuid):
         vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)
         sm_config = self._session.xenapi.VDI.get_sm_config(vdi_ref)

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1715,9 +1715,7 @@ class VDI(object):
         options = {"rdonly": not writable}
         options.update(caching_params)
 
-        sr_ref = self.target.vdi.sr.srcmd.params.get('sr_ref')
-        sr_other_config = self._session.xenapi.SR.get_other_config(sr_ref)
-        for i in range(self.ATTACH_DETACH_RETRY_SECS):
+        for _ in range(self.ATTACH_DETACH_RETRY_SECS):
             try:
                 if self._activate_locked(sr_uuid, vdi_uuid, options):
                     return

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1609,6 +1609,7 @@ class VDI(object):
             return False
         return True
 
+    @util.call_XAPI_until_httpOK
     def _remove_tag(self, vdi_uuid):
         vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)
         host_ref = self._session.xenapi.host.get_by_uuid(util.get_this_host())
@@ -1871,22 +1872,9 @@ class VDI(object):
             util.SMlog("Exception in activate/attach")
             if self.tap_wanted():
                 util.fistpoint.activate_custom_fn(
-                        "blktap_activate_error_handling",
-                        lambda: time.sleep(30))
-                while True:
-                    try:
-                        self._remove_tag(vdi_uuid)
-                        break
-                    except xmlrpc.client.ProtocolError as e:
-                        # If there's a connection error, keep trying forever.
-                        if e.errcode == http.HTTPStatus.INTERNAL_SERVER_ERROR.value:
-                            continue
-                        else:
-                            util.SMlog('failed to remove tag: %s' % e)
-                            break
-                    except Exception as e:
-                        util.SMlog('failed to remove tag: %s' % e)
-                        break
+                    "blktap_activate_error_handling",
+                    lambda: time.sleep(30))
+                self._remove_tag(vdi_uuid)
             raise
         finally:
             vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)
@@ -1952,7 +1940,6 @@ class VDI(object):
             self._detach(sr_uuid, vdi_uuid)
         if self.tap_wanted():
             self._remove_tag(vdi_uuid)
-
         return True
 
     def _resetPhylink(self, sr_uuid, vdi_uuid, path):

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -784,14 +784,14 @@ def get_localAPI_session():
     return session
 
 
-def call_XAPI_until_httpOK(function):
+def xapi_safe_call(function):
     """
-    Decorator to catch classic XAPI connexion problems and retry forever
-    The method called should be only for XAPI calls
+    Decorator to catch classic XAPI connection problems and retry forever.
+    The method should be only called for XAPI calls.
     eg: blktap2.py#VDI:_remove_tag()
     """
     def wrapper(*args, **kwargs):
-        errmsg = f"{function.__name__}(args={args}, kwargs={kwargs})"
+        call_str = f"{function.__name__}(args={args}, kwargs={kwargs})"
         while True:
             try:
                 return function(*args, **kwargs)
@@ -799,10 +799,9 @@ def call_XAPI_until_httpOK(function):
                 # If there's a connection error, keep trying forever.
                 if e.errcode == http.HTTPStatus.INTERNAL_SERVER_ERROR.value:
                     continue
-                SMlog(f"failed XAPI call [{e}]: {errmsg}")
                 raise
             except Exception as e:
-                SMlog(f"failed XAPI call [{e}]: {errmsg}")
+                SMlog(f"Failed XAPI call `{call_str}`: `{e}`")
                 raise
     return wrapper
 

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -39,6 +39,7 @@ import stat
 import xs_errors
 import XenAPI # pylint: disable=import-error
 import xmlrpc.client
+import http.client
 import base64
 import syslog
 import resource
@@ -781,6 +782,29 @@ def get_localAPI_session():
     except:
         raise xs_errors.XenError('APISession')
     return session
+
+
+def call_XAPI_until_httpOK(function):
+    """
+    Decorator to catch classic XAPI connexion problems and retry forever
+    The method called should be only for XAPI calls
+    eg: blktap2.py#VDI:_remove_tag()
+    """
+    def wrapper(*args, **kwargs):
+        errmsg = f"{function.__name__}(args={args}, kwargs={kwargs})"
+        while True:
+            try:
+                return function(*args, **kwargs)
+            except xmlrpc.client.ProtocolError as e:
+                # If there's a connection error, keep trying forever.
+                if e.errcode == http.HTTPStatus.INTERNAL_SERVER_ERROR.value:
+                    continue
+                SMlog(f"failed XAPI call [{e}]: {errmsg}")
+                raise
+            except Exception as e:
+                SMlog(f"failed XAPI call [{e}]: {errmsg}")
+                raise
+    return wrapper
 
 
 def get_this_host():


### PR DESCRIPTION
Decorator to retry a method when it fails with HTTPStatus.INTERNAL_SERVER_ERROR
Should only be used for replayable XAPI operations.