### PR TITLE
Add IO import in sm_typing

### DIFF
--- a/sm_typing/__init__.py
+++ b/sm_typing/__init__.py
@@ -1,6 +1,10 @@
 import typing
 from typing import *
 
+# Manually importing `IO` for python 3.6 because it is not in `typing.__all__`
+# and so, not imported by the statement above.
+from typing import IO
+
 if not hasattr(typing, 'override'):
     def override(method): # type: ignore
         try:


### PR DESCRIPTION
Fixes an issue where IO was not imported with the
global import statement, since IO is not in `typing.__all__`
in python 3.6.

This causes an issue when trying to import IO from sm_typing.