### PR TITLE
fix(linstor): explicitly notifies a missing res def

### DIFF
--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -960,7 +960,13 @@ class LinstorVolumeManager(object):
         """
 
         volume_name = self.get_volume_name(volume_uuid)
-        return self._get_volumes_info()[volume_name]
+        try:
+            return self._get_volumes_info()[volume_name]
+        except KeyError:
+            raise LinstorVolumeManagerError(
+                f"Could not find info about volume `{volume_uuid}`, the resource definition has likely been deleted",
+                LinstorVolumeManagerError.ERR_VOLUME_NOT_EXISTS
+            )
 
     def get_device_path(self, volume_uuid):
         """


### PR DESCRIPTION
Prior to this change, a `KeyError` was raised that didn't indicate why a volume info was not found in the event of a missing resource definition.