### PR TITLE
fix(linstor): handle RAW type in compute_volume_size

### DIFF
--- a/drivers/linstorcowutil.py
+++ b/drivers/linstorcowutil.py
@@ -474,7 +474,7 @@ class LinstorCowUtil:
             )
             bitmap_overhead = self._cowutil.calcOverheadBitmap(virtual_size)
             virtual_size += meta_overhead + bitmap_overhead
-        else:
+        elif self._vdi_type != VdiType.RAW:
             raise Exception('Invalid image type: {}'.format(self._vdi_type))
 
         return LinstorVolumeManager.round_up_volume_size(virtual_size)


### PR DESCRIPTION
Regression caused by this commit:
```
refactor(sm): move all VDI types in a new module `vditype.py`
```

The RAW type is no longer checked by this function; this prevents the creation of RAW volumes and consequently blocks HA activation.