### PR TITLE
fix(linstor): deal with missing group during SR creation

### DIFF
--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1936,7 +1936,7 @@ class LinstorVolumeManager(object):
                     result
                 )
                 if errors:
-                    if len(errors) == 1 and errors[0].is_error(
+                    if errors[0].is_error(
                         linstor.consts.FAIL_STOR_POOL_CONFIGURATION_ERROR
                     ) and reg_volume_group_not_found.match(errors[0].message):
                         logger(


### PR DESCRIPTION
An update of the LINSTOR RPMs changes the behavior of the `storage_pool_create` function. It seems that we now receive two errors instead of one, which prevented us from entering the "missing LVM group" code branch during SR creation. As reminder, it's tolerated to have VGs not present on some nodes, it's why we have a specific code to deal with it.

API errors when a group is missing:
```
[RESTMessageResponse({'ret_code': -4611686018409298978, 'message': "(xcp-node-1) Volume group 'linstor_group' not found", 'obj_refs': {'StorPoolDfn': 'test', 'Node': 'xcp-node-1'}, 'created_at': '2026-08-31T16:35:29.487312-04:00'}), RESTMessageResponse({'ret_code': -4611686018409298970, 'message': "Registration of storage pool 'test' on node 'xcp-node-1' failed due to an unhandled exception of type DelayedApiRcException. Exceptions have been converted to responses", 'details': 'Node: xcp-node-1, Storage pool name: test', 'error_report_ids': ['6A95E399-00000-000002'], 'obj_refs': {'StorPoolDfn': 'test', 'Node': 'xcp-node-1'}, 'created_at': '2026-08-31T16:35:29.494205-04:00'})]
```