### PR TITLE
SR.scan: mark gone VDIs missing instead of forgetting

### DIFF
--- a/libs/sm/SR.py
+++ b/libs/sm/SR.py
@@ -596,12 +596,13 @@ class ScanRecord:
             vdi._db_introduce()
 
     def synchronise_gone(self):
-        """Delete XenAPI record for old disks"""
+        """Mark XenAPI records missing for old disks"""
         for location in self.gone:
             vdi = self.get_xenapi_vdi(location)
-            util.SMlog("Forgetting VDI with location=%s uuid=%s" % (util.to_plain_string(vdi['location']), vdi['uuid']))
+            util.SMlog("Marking VDI as missing: location=%s uuid=%s" %
+                       (util.to_plain_string(vdi['location']), vdi['uuid']))
             try:
-                self.sr.forget_vdi(vdi['uuid'])
+                self.sr.session.xenapi.VDI.set_missing(self.sr.session.xenapi.VDI.get_by_uuid(vdi['uuid']), True)
             except XenAPI.Failure as e:
                 if util.isInvalidVDI(e):
                     util.SMlog("VDI %s not found, ignoring exception" %
@@ -617,9 +618,31 @@ class ScanRecord:
             util.SMlog("Updating VDI with location=%s uuid=%s" % (vdi.location, vdi.uuid))
             vdi._db_update()
 
+    def _clear_missing_vdi(self):
+        """Clear missing flag for VDIs present on disk again"""
+        for location in self.all_xenapi_locations():
+            try:
+                self.get_sm_vdi(location)
+            except KeyError:
+                continue
+            vdi = self.get_xenapi_vdi(location)
+            if not vdi.get('missing'):
+                continue
+            util.SMlog("Clearing missing flag: location=%s uuid=%s" %
+                       (util.to_plain_string(location), vdi['uuid']))
+            try:
+                self.sr.session.xenapi.VDI.set_missing(self.sr.session.xenapi.VDI.get_by_uuid(vdi['uuid']), False)
+            except XenAPI.Failure as e:
+                if util.isInvalidVDI(e):
+                    util.SMlog("VDI %s not found, ignoring exception" %
+                               vdi['uuid'])
+                else:
+                    raise
+
     def synchronise(self):
         """Perform the default SM -> xenapi synchronisation; ought to be good enough
         for most plugins."""
         self.synchronise_new()
         self.synchronise_gone()
         self.synchronise_existing()
+        self._clear_missing_vdi()

--- a/tests/test_SR.py
+++ b/tests/test_SR.py
@@ -86,3 +86,55 @@ class TestSR(unittest.TestCase):
                       mock_log.call_args[0][0])
         mock_session.xenapi.message.create.assert_called_once_with(
             "POST_ATTACH_SCAN_FAILED", 2, 'SR', 'dummy uuid', mock.ANY)
+
+    def test_synchronise_gone_marks_missing(self):
+        sr = mock.MagicMock()
+        session = sr.session
+        vdi_ref = 'OpaqueRef:vdi'
+        session.xenapi.VDI.get_by_uuid.return_value = vdi_ref
+
+        record = mock.Mock()
+        record.sr = sr
+        record.gone = {'gone-location'}
+        record.get_xenapi_vdi.return_value = {
+            'location': 'gone-location',
+            'uuid': 'vdi-uuid',
+        }
+
+        SR.ScanRecord.synchronise_gone(record)
+
+        session.xenapi.VDI.set_missing.assert_called_once_with(vdi_ref, True)
+        sr.forget_vdi.assert_not_called()
+
+    def test_clear_missing_vdi_when_present(self):
+        sr = mock.MagicMock()
+        session = sr.session
+        vdi_ref = 'OpaqueRef:vdi'
+        session.xenapi.VDI.get_by_uuid.return_value = vdi_ref
+
+        record = mock.Mock()
+        record.sr = sr
+        record.all_xenapi_locations.return_value = {'present-location'}
+        record.get_sm_vdi.return_value = mock.Mock()
+        record.get_xenapi_vdi.return_value = {
+            'location': 'present-location',
+            'uuid': 'vdi-uuid',
+            'missing': True,
+        }
+
+        SR.ScanRecord._clear_missing_vdi(record)
+
+        session.xenapi.VDI.set_missing.assert_called_once_with(vdi_ref, False)
+
+    def test_clear_missing_vdi_skips_gone(self):
+        sr = mock.MagicMock()
+        session = sr.session
+
+        record = mock.Mock()
+        record.sr = sr
+        record.all_xenapi_locations.return_value = {'gone-location'}
+        record.get_sm_vdi.side_effect = KeyError('gone-location')
+
+        SR.ScanRecord._clear_missing_vdi(record)
+
+        session.xenapi.VDI.set_missing.assert_not_called()


### PR DESCRIPTION
SR.scan used to forget gone VDI, so during a later scan it recover and dropped name-label and snapshot metadata. Mark gone VDIs missing instead (like ISOSR), and clear the flag when they are on disk again.