### PR TITLE
fix(linstor): handle volume creation failure in clone rollback

### DIFF
--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -1481,6 +1481,18 @@ class LinstorSR(SR.SR):
                 # properly the base VDI below this line, so we must change the
                 # UUID of this bad VDI before.
                 self._linstor.mark_volume_for_deletion(vdi_uuid, force=True)
+        else:
+            not_exists_state = self._linstor.get_volume_not_exists_state(vdi_uuid)
+
+            if not_exists_state and not_exists_state != LinstorVolumeManager.STATE_EXISTS:
+                # At this point, some of the new volume properties were created,
+                # but volume creation was interrupted before the volume itself
+                # could be physically created.
+                # We mark this new volume for deletion so that the base VDI UUID
+                # can be restored back to its original value.
+                util.SMlog(f"VDI {vdi_uuid} was partially created, marking it for deletion")
+
+                self._linstor.mark_volume_for_deletion(vdi_uuid, force=True)
 
         # Rename!
         self._linstor.update_volume_uuid(base_uuid, vdi_uuid)

--- a/drivers/LinstorSR.py
+++ b/drivers/LinstorSR.py
@@ -27,6 +27,7 @@ try:
     from linstorvolumemanager import LinstorVolumeManagerError
     from linstorvolumemanager import DATABASE_VOLUME_NAME
     from linstorvolumemanager import PERSISTENT_PREFIX
+    from linstorvolumemanager import DELETED_PREFIX
 
     LINSTOR_AVAILABLE = True
 except ImportError:
@@ -1114,7 +1115,7 @@ class LinstorSR(SR.SR):
                 if not introduce:
                     continue
 
-                if vdi_uuid.startswith('DELETED_'):
+                if vdi_uuid.startswith(DELETED_PREFIX):
                     continue
 
                 volume_metadata = volumes_metadata.get(vdi_uuid)
@@ -1479,9 +1480,7 @@ class LinstorSR(SR.SR):
                 # volume info remains... The problem is we can't rename
                 # properly the base VDI below this line, so we must change the
                 # UUID of this bad VDI before.
-                self._linstor.update_volume_uuid(
-                    vdi_uuid, 'DELETED_' + vdi_uuid, force=True
-                )
+                self._linstor.mark_volume_for_deletion(vdi_uuid, force=True)
 
         # Rename!
         self._linstor.update_volume_uuid(base_uuid, vdi_uuid)

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -61,6 +61,7 @@ try:
     from linstorvolumemanager import get_controller_uri
     from linstorvolumemanager import LinstorVolumeManager, LinstorVolumeManagerError, LinstorVolumeOpeners
     from linstorvolumemanager import PERSISTENT_PREFIX as LINSTOR_PERSISTENT_PREFIX
+    from linstorvolumemanager import DELETED_PREFIX as LINSTOR_DELETED_PREFIX
 
     LINSTOR_AVAILABLE = True
 except ImportError:
@@ -2916,7 +2917,7 @@ class SR(object):
             vdi._coalesceCowImageOnHost(host_ref, vdi) # vdi is the leaf for the online coalesce
             util.fistpoint.activate("LVHDRT_coaleaf_after_coalesce", self.uuid)
             vdi.pause(failfast=True)
-            # We make a pause here after the online coalesce but before the rename so we can refresh the chain for tapdisk. 
+            # We make a pause here after the online coalesce but before the rename so we can refresh the chain for tapdisk.
             # It's also needed to be paused for the rename on slaves with LVMSR.
             # We let the caller `_liveLeafCoalesce` do the unpause with the call to `vdi.ensureUnpaused()`
         else:
@@ -3744,7 +3745,7 @@ class LinstorSR(SR):
                 if not volume_info.name and not list(volume_metadata.items()):
                     continue  # Ignore it, probably deleted.
 
-                if vdi_uuid.startswith('DELETED_'):
+                if vdi_uuid.startswith(LINSTOR_DELETED_PREFIX):
                     # Assume it's really a RAW volume of a failed snap without COW header/footer.
                     # We must remove this VDI now without adding it in the VDI list.
                     # Otherwise `Relinking` calls and other actions can be launched on it.

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1060,9 +1060,10 @@ class LinstorVolumeManager(object):
                 .format(volume_uuid)
             )
 
-        # 1. Copy in temp variables metadata and volume_name.
+        # 1. Copy in temp variables metadata, volume_name and not_exists.
         metadata = volume_properties.get(self.PROP_METADATA)
         volume_name = volume_properties.get(self.PROP_VOLUME_NAME)
+        not_exists = volume_properties.get(self.PROP_NOT_EXISTS)
 
         # 2. Switch to new volume namespace.
         volume_properties.namespace = self._build_volume_namespace(
@@ -1093,7 +1094,7 @@ class LinstorVolumeManager(object):
             volume_properties[self.PROP_VOLUME_NAME] = volume_name
 
             # 5. Ok!
-            volume_properties[self.PROP_NOT_EXISTS] = self.STATE_EXISTS
+            volume_properties[self.PROP_NOT_EXISTS] = not_exists
         except Exception as err:
             try:
                 # Clear the new volume properties in case of failure.
@@ -1138,7 +1139,8 @@ class LinstorVolumeManager(object):
             # we are processing a deleted resource.
             assert force
 
-        self._volumes.add(new_volume_uuid)
+        if not_exists == self.STATE_EXISTS:
+            self._volumes.add(new_volume_uuid)
 
         self._logger(
             'UUID update succeeded of {} to {}! (properties={})'

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -1344,6 +1344,20 @@ class LinstorVolumeManager(object):
             current_metadata[key] = value
         volume_properties[self.PROP_METADATA] = json.dumps(current_metadata)
 
+    def get_volume_not_exists_state(self, volume_uuid):
+        """
+        Get the "not-exists" state of a volume.
+        :param str volume_uuid: The target volume.
+        :return: The "not-exists" state.
+        :rtype: Optional[str]
+        """
+
+        # We do not ensure that the volume exists since it might not
+        # physically exist (for example, the volume creation failed), but it
+        # might still have had its "not-exists" property set.
+        volume_properties = self._get_volume_properties(volume_uuid)
+        return volume_properties.get(self.PROP_NOT_EXISTS)
+
     def shallow_clone_volume(self, volume_uuid, clone_uuid, persistent=True):
         """
         Clone a volume. Do not copy the data, this method creates a new volume

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -37,6 +37,9 @@ import uuid
 # Persistent prefix to add to RAW persistent volumes.
 PERSISTENT_PREFIX = 'xcp-persistent-'
 
+# Prefix added to the UUID of a LINSTOR volume that will be deleted by the GC.
+DELETED_PREFIX = 'DELETED_'
+
 # Contains the data of the "/var/lib/linstor" directory.
 DATABASE_VOLUME_NAME = PERSISTENT_PREFIX + 'database'
 DATABASE_SIZE = 1 << 30  # 1GB.
@@ -1141,6 +1144,20 @@ class LinstorVolumeManager(object):
                 volume_uuid, new_volume_uuid,
                 self._get_filtered_properties(volume_properties)
             )
+        )
+
+    def mark_volume_for_deletion(self, volume_uuid, force=False):
+        """
+        Add a prefix to the volume UUID to mark it for deletion by the GC.
+        :param str volume_uuid: The volume to mark.
+        :param bool force: Whether to force-update the volume UUID. See the
+        documentation of `update_volume_uuid` for more details.
+        """
+        if volume_uuid.startswith(DELETED_PREFIX):
+            return
+
+        self.update_volume_uuid(
+            volume_uuid, DELETED_PREFIX + volume_uuid, force=force
         )
 
     def update_volume_name(self, volume_uuid, volume_name):
@@ -2599,10 +2616,7 @@ class LinstorVolumeManager(object):
                 # This prefix is mandatory if it exists a snap transaction to
                 # rollback because the original VDI UUID can try to be renamed
                 # with the UUID we are trying to delete...
-                if not volume_uuid.startswith('DELETED_'):
-                    self.update_volume_uuid(
-                        volume_uuid, 'DELETED_' + volume_uuid, force=True
-                    )
+                self.mark_volume_for_deletion(volume_uuid, force=True)
 
         for dest_uuid, src_uuid in updating_uuid_volumes.items():
             dest_namespace = self._build_volume_namespace(dest_uuid)

--- a/drivers/linstorvolumemanager.py
+++ b/drivers/linstorvolumemanager.py
@@ -244,7 +244,8 @@ class LinstorVolumeManagerError(Exception):
     ERR_VOLUME_NOT_EXISTS = 2,
     ERR_VOLUME_DESTROY = 3,
     ERR_GROUP_NOT_EXISTS = 4,
-    ERR_VOLUME_IN_USE = 5
+    ERR_VOLUME_IN_USE = 5,
+    ERR_VOLUME_PROPERTIES_NOT_EMPTY = 6
 
     def __init__(self, message, code=ERR_GENERIC):
         super(LinstorVolumeManagerError, self).__init__(message)
@@ -1072,7 +1073,8 @@ class LinstorVolumeManager(object):
             raise LinstorVolumeManagerError(
                 'Cannot update volume uuid {} to {}: '
                 .format(volume_uuid, new_volume_uuid) +
-                'this last one is not empty'
+                'this last one is not empty',
+                LinstorVolumeManagerError.ERR_VOLUME_PROPERTIES_NOT_EMPTY
             )
 
         try:
@@ -1156,9 +1158,23 @@ class LinstorVolumeManager(object):
         if volume_uuid.startswith(DELETED_PREFIX):
             return
 
-        self.update_volume_uuid(
-            volume_uuid, DELETED_PREFIX + volume_uuid, force=force
-        )
+        deleted_prefix_counter = 0
+        while True:
+            new_volume_uuid = '{}{}_{}'.format(
+                DELETED_PREFIX, deleted_prefix_counter, volume_uuid
+            )
+
+            try:
+                self.update_volume_uuid(
+                    volume_uuid, new_volume_uuid, force=force
+                )
+
+                break
+            except LinstorVolumeManagerError as e:
+                if e.code != LinstorVolumeManagerError.ERR_VOLUME_PROPERTIES_NOT_EMPTY:
+                    raise
+
+                deleted_prefix_counter += 1
 
     def update_volume_name(self, volume_uuid, volume_name):
         """


### PR DESCRIPTION
A clone rollback may be initiated because the new volume could not be physically created. This can be detected by checking the `not-exists` property of this volume.

If this property tells us that the new volume doesn't actually exist, then we mark it for later deletion by the GC so that rolling back the UUID of the base VDI doesn't fail later on.