### PR TITLE
Fix undo leaf coalesce not working with QCOW2 live leaf coalesce

### DIFF
--- a/drivers/LVMSR.py
+++ b/drivers/LVMSR.py
@@ -1864,8 +1864,12 @@ class LVMVDI(VDI.VDI):
             util.fistpoint.activate("LVHDRT_clone_vdi_after_parent_hidden", self.sr.uuid)
 
             # set the base copy to ReadOnly
-            self.sr.lvmCache.setReadonly(self.lvname, True)
-            util.fistpoint.activate("LVHDRT_clone_vdi_after_parent_ro", self.sr.uuid)
+            if not self.cowutil.isCoalesceableOnRemote():
+                # For QCOW2, the whole chain need to be
+                # writable for tapdisk to do the coalesce.
+                # In this case, we don't mark the base copy RO.
+                self.sr.lvmCache.setReadonly(self.lvname, True)
+                util.fistpoint.activate("LVHDRT_clone_vdi_after_parent_ro", self.sr.uuid)
 
             if hostRefs:
                 self.sr._updateSlavesOnClone(hostRefs, origOldLV,

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -606,6 +606,10 @@ class VDI(object):
         self.sr.xapi.removeFromConfigVDI(self, key)
         Util.log("Removed %s from %s" % (key, self))
 
+    def ensurePaused(self):
+        if not self.getConfig(self.DB_VDI_PAUSED) == "true":
+            self.pause(failfast=True)
+
     def ensureUnpaused(self):
         if self.getConfig(self.DB_VDI_PAUSED) == "true":
             Util.log("Unpausing VDI %s" % self)
@@ -3509,6 +3513,7 @@ class LVMSR(SR):
             parent._setHidden(True)
         if not parent.lvReadonly:
             self.lvmCache.setReadonly(parent.fileName, True)
+        child.ensurePaused()
         self._updateSlavesOnUndoLeafCoalesce(parent, child)
         util.fistpoint.activate("LVHDRT_coaleaf_undo_end", self.uuid)
         Util.log("*** leaf-coalesce undo successful")


### PR DESCRIPTION
This PR fixes two bugs:
- An undo live leaf coalesce could find the chain being used and stopping it from doing LV refresh on LVMo{ISCIS,HBA}
- A VDI snapshot on a QCOW2 VDI would make the base copy read only when it would be expected to be RW when in use for the live coalesce to be done, it would cause `tap-ctl commit` to fail with `Operation not supported`